### PR TITLE
Upgrade to 1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## v0.8.0
+## v0.9.0
 
 ### Changed
 
 - Migrated to be deployed via an app CR not a chartconfig CR.
+
+## [v0.8.0]
+
+### Added
+
+- Change CoreDNS version to `1.6.4` with different enhancements and fixes.
+  - [1.6.3 release notes](https://coredns.io/2019/08/31/coredns-1.6.3-release/).
+  - [1.6.4 release notes](https://coredns.io/2019/09/27/coredns-1.6.4-release/).
 
 ## [v0.7.0]
 

--- a/helm/coredns-app/templates/deployment.yaml
+++ b/helm/coredns-app/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
-        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         args: [ "-conf", "/etc/coredns/Corefile", "-dns.port", "1053" ]
         securityContext:

--- a/helm/coredns-app/templates/test/test-runner.yaml
+++ b/helm/coredns-app/templates/test/test-runner.yaml
@@ -9,7 +9,7 @@ spec:
   # Bash automated testing system
   # https://github.com/bats-core/bats-core
   - name: test-framework
-    image: {{ .Values.test.image.registry }}/giantswarm/bats:0.4.0
+    image: {{ .Values.image.registry }}/giantswarm/bats:0.4.0
     command:
     - "bash"
     - "-c"
@@ -22,7 +22,7 @@ spec:
       name: tools
   containers:
   - name: {{ .Values.name }}-test
-    image: "{{ .Values.test.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
+    image: "{{ .Values.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
     imagePullPolicy: IfNotPresent
     command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
     volumeMounts:

--- a/helm/coredns-app/templates/test/test-runner.yaml
+++ b/helm/coredns-app/templates/test/test-runner.yaml
@@ -22,7 +22,7 @@ spec:
       name: tools
   containers:
   - name: {{ .Values.name }}-test
-    image: "{{ .Values.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
+    image: "{{ .Values.image.registry }}/{{ .Values.test.image.name }}:{{ .Values.test.image.tag }}"
     imagePullPolicy: IfNotPresent
     command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
     volumeMounts:

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -22,7 +22,7 @@ configmap:
 image:
   registry: quay.io
   repository: giantswarm/coredns
-  tag: 1.6.2
+  tag: 1.6.4
 
 updateStrategy:
   type: RollingUpdate

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -21,7 +21,7 @@ configmap:
 
 image:
   registry: quay.io
-  repository: giantswarm/coredns
+  name: giantswarm/coredns
   tag: 1.6.4
 
 updateStrategy:
@@ -50,6 +50,5 @@ loadbalancePolicy: round_robin
 
 test:
   image:
-    registry: quay.io
-    repository: giantswarm/alpine-testing
+    name: giantswarm/alpine-testing
     tag: 0.1.1


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/kubernetes-coredns/pull/49.

Upgrades the version and improves the image templating.