### PR TITLE
Increment version to 1.0.0 for move to default app catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ data:
 
 - Remove `proxy` configuration support as it is [deprecated by upstream](https://coredns.io/2019/03/03/coredns-1.4.0-release/). New server block with `forward` plugin has to be used, more info in our [docs](https://docs.giantswarm.io/guides/advanced-coredns-configuration/).
 
+[1.0.0]: https://github.com/giantswarm/coredns-app/pull/6
 [0.8.0]: https://github.com/giantswarm/kubernetes-coredns/pull/49
 [0.7.0]: https://github.com/giantswarm/kubernetes-coredns/pull/46
 [0.6.2]: https://github.com/giantswarm/kubernetes-coredns/pull/36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## v0.9.0
+## [v1.0.0]
 
 ### Changed
 
@@ -110,6 +110,7 @@ data:
 
 - Remove `proxy` configuration support as it is [deprecated by upstream](https://coredns.io/2019/03/03/coredns-1.4.0-release/). New server block with `forward` plugin has to be used, more info in our [docs](https://docs.giantswarm.io/guides/advanced-coredns-configuration/).
 
+[0.8.0]: https://github.com/giantswarm/kubernetes-coredns/pull/49
 [0.7.0]: https://github.com/giantswarm/kubernetes-coredns/pull/46
 [0.6.2]: https://github.com/giantswarm/kubernetes-coredns/pull/36
 [0.6.1]: https://github.com/giantswarm/kubernetes-coredns/pull/32


### PR DESCRIPTION
We agreed in @giantswarm/team-batman that the apps being moved to the default app catalog would be 1.x. Since they are fully supported.