### PR TITLE
Allow CoreDNS to be scheduled on master

### DIFF
--- a/helm/coredns-app/templates/deployment.yaml
+++ b/helm/coredns-app/templates/deployment.yaml
@@ -42,6 +42,11 @@ spec:
                     values:
                     - {{ .Values.name }}
               topologyKey: kubernetes.io/hostname
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
       containers:
       - name: coredns
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
With Node Pool clusters it's a valid use case to run cluster without any
workers (i.e. without any node pools). This can also happen during cluster
re-configuration when switching workers from one AZ to another. In order to
have functional in-cluster DNS resolving, it's required to allow CoreDNS to be
scheduled on master node.

Towards https://github.com/giantswarm/giantswarm/issues/7082