### PR TITLE
Use upstream coredns version 1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.0.1]
+
+### Changed
+
+- Updated coredns to upstream version [1.6.5](https://coredns.io/2019/11/05/coredns-1.6.5-release/).
+
 ## [v1.0.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [v1.0.1]
+## [v1.1.0]
 
 ### Changed
 

--- a/helm/coredns-app/Chart.yaml
+++ b/helm/coredns-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.6.2
+appVersion: 1.6.5
 description: A Helm chart for CoreDNS
 name: coredns-app
 version: [[ .Version ]]

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -22,7 +22,7 @@ configmap:
 image:
   registry: quay.io
   name: giantswarm/coredns
-  tag: 1.6.4
+  tag: 1.6.5
 
 updateStrategy:
   type: RollingUpdate


### PR DESCRIPTION
Update coredns to upstream version 1.6.5 (from 1.6.4) towards https://github.com/giantswarm/giantswarm/issues/7428

No breaking changes listed in release notes