### PR TITLE
Allow custom config to be defined in de default server configuration

### DIFF
--- a/helm/coredns-app/templates/configmap.yaml
+++ b/helm/coredns-app/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
           pods verified
           upstream
         }
+{{ .Values.configmap.customDefaultConfig | indent 8 }}
         log . {
           {{- range (.Values.configmap.log | trimAll "\n " |  split "\n") }}
           class {{ . }}

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -19,6 +19,7 @@ configmap:
   log: |
     denial
     error
+  customDefaultConfig: ""
 
 image:
   registry: quay.io


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8979

Allows custom configuration of coreDNS, for example custom dns forward:

```
configmap:
  customDefaultConfig: |
    forward us-east-1.local 10.144.1.150:53 {
      force_tcp
    }
```