### PR TITLE
Fix broken 1.1.8 changelog link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@ data:
 
 - Remove `proxy` configuration support as it is [deprecated by upstream](https://coredns.io/2019/03/03/coredns-1.4.0-release/). New server block with `forward` plugin has to be used, more info in our [docs](https://docs.giantswarm.io/guides/advanced-coredns-configuration/).
 
+[v1.1.8]: https://github.com/giantswarm/coredns-app/pull/20
 [v1.1.7]: https://github.com/giantswarm/coredns-app/pull/19
 [v1.1.6]: https://github.com/giantswarm/coredns-app/pull/17
 [v1.1.5]: https://github.com/giantswarm/coredns-app/pull/16


### PR DESCRIPTION
We missed this in https://github.com/giantswarm/coredns-app/pull/20
There's no need for new release just because of this.