### PR TITLE
Remove depricate upstream option

### DIFF
--- a/helm/coredns-app/templates/configmap.yaml
+++ b/helm/coredns-app/templates/configmap.yaml
@@ -17,7 +17,6 @@ data:
         kubernetes {{ .Values.cluster.kubernetes.clusterDomain }} {{ .Values.cluster.kubernetes.API.clusterIPRange }} {{ .Values.cluster.calico.CIDR }} {
           fallthrough in-addr.arpa ip6.arpa
           pods verified
-          upstream
         }
         log . {
           {{- range (.Values.configmap.log | trimAll "\n " |  split "\n") }}


### PR DESCRIPTION
In coredns v1.3.1 , [Release notes](https://coredns.io/2019/01/13/coredns-1.3.1-release/), the `upstream` directive has been moved to start in the default coredns process instead of having to specify it in the kubernetes coredns plugin.

In coredns v1.7.0, this option has been removed and coredns will fail to start if present.

plugin/kubernetes: Remove already-deprecated options resyncperiod and upstream (coredns/coredns#3737)

[https://coredns.io/2020/06/15/coredns-1.7.0-release/](https://coredns.io/2020/06/15/coredns-1.7.0-release/)