### PR TITLE
Coredns 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Updated coredns to upstream version [1.8.0](https://coredns.io/2020/10/22/coredns-1.8.0-release/).
+- Updated coredns to upstream version [1.6.9](https://coredns.io/2020/03/24/coredns-1.6.9-release/).
 
 ## [v1.2.0] 2020-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Updated coredns to upstream version [1.6.9](https://coredns.io/2020/03/24/coredns-1.6.9-release/).
+- Updated coredns to upstream version [1.7.1](https://coredns.io/2020/09/21/coredns-1.7.1-release/).
 
 ## [v1.2.0] 2020-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Updated coredns to upstream version [1.7.1](https://coredns.io/2020/09/21/coredns-1.7.1-release/).
+- Updated `coredns` to upstream version [1.7.1](https://coredns.io/2020/09/21/coredns-1.7.1-release/) (including changes introduced in version [1.7.0](https://coredns.io/2020/06/15/coredns-1.7.0-release/)).
 
 ## [1.2.1] - 2021-02-05
 
@@ -19,7 +19,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Updated coredns to upstream version [1.6.9](https://coredns.io/2020/03/24/coredns-1.6.9-release/).
+- Updated `coredns` to upstream version [1.6.9](https://coredns.io/2020/03/24/coredns-1.6.9-release/).
 
 ## [v1.2.0] 2020-07-13
 

--- a/helm/coredns-app/Chart.yaml
+++ b/helm/coredns-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.8.0
+appVersion: 1.6.9
 description: A Helm chart for CoreDNS
 home: https://github.com/giantswarm/coredns-app
 name: coredns-app

--- a/helm/coredns-app/Chart.yaml
+++ b/helm/coredns-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.6.9
+appVersion: 1.7.1
 description: A Helm chart for CoreDNS
 home: https://github.com/giantswarm/coredns-app
 name: coredns-app

--- a/helm/coredns-app/templates/configmap.yaml
+++ b/helm/coredns-app/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
         kubernetes {{ .Values.cluster.kubernetes.clusterDomain }} {{ .Values.cluster.kubernetes.API.clusterIPRange }} {{ .Values.cluster.calico.CIDR }} {
           fallthrough in-addr.arpa ip6.arpa
           pods verified
+          upstream
         }
         log . {
           {{- range (.Values.configmap.log | trimAll "\n " |  split "\n") }}

--- a/helm/coredns-app/templates/configmap.yaml
+++ b/helm/coredns-app/templates/configmap.yaml
@@ -17,7 +17,6 @@ data:
         kubernetes {{ .Values.cluster.kubernetes.clusterDomain }} {{ .Values.cluster.kubernetes.API.clusterIPRange }} {{ .Values.cluster.calico.CIDR }} {
           fallthrough in-addr.arpa ip6.arpa
           pods verified
-          upstream
         }
         log . {
           {{- range (.Values.configmap.log | trimAll "\n " |  split "\n") }}

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-name: coredns
+name: coredns-app
 namespace: kube-system
 serviceType: managed
 
@@ -29,7 +29,7 @@ configmap:
 image:
   registry: quay.io
   name: giantswarm/coredns
-  tag: 1.8.0
+  tag: 1.6.9
 
 updateStrategy:
   type: RollingUpdate

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-name: coredns-app
+name: coredns
 namespace: kube-system
 serviceType: managed
 

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -29,7 +29,7 @@ configmap:
 image:
   registry: quay.io
   name: giantswarm/coredns
-  tag: 1.6.9
+  tag: 1.7.1
 
 updateStrategy:
   type: RollingUpdate


### PR DESCRIPTION
Upversion to upstream coredns version 1.7.1

Release notes: 
- [https://coredns.io/2020/06/15/coredns-1.7.0-release/](https://coredns.io/2020/06/15/coredns-1.7.0-release/) **breaking changes are present**
- [https://coredns.io/2020/09/21/coredns-1.7.1-release/](https://coredns.io/2020/09/21/coredns-1.7.1-release/)

https://github.com/giantswarm/coredns-app/pull/69 needs to be merged and coredns-app needs to be versioned before this change can be merged