### PR TITLE
Add toleration to allow scheduling in master nodes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Add toleration to allow scheduling in master nodes.
+- Add deployment to run one replica of coredns in master nodes (for clusters with no node pools).
 
 ## [1.7.0] - 2022-01-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add toleration to allow scheduling in master nodes.
+
 ## [1.7.0] - 2022-01-04
 
 ### Changed
@@ -231,8 +235,7 @@ data:
 
 - Remove `proxy` configuration support as it is [deprecated by upstream](https://coredns.io/2019/03/03/coredns-1.4.0-release/). New server block with `forward` plugin has to be used, more info in our [docs](https://docs.giantswarm.io/guides/advanced-coredns-configuration/).
 
-[Unreleased]: https://github.com/giantswarm/coredns-app/compare/v1.7.0...HEAD
-[1.7.0]: https://github.com/giantswarm/coredns-app/compare/v1.6.0...v1.7.0
+[Unreleased]: https://github.com/giantswarm/coredns-app/compare/v1.6.0...HEAD
 [1.6.0]: https://github.com/giantswarm/coredns-app/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/giantswarm/coredns-app/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/giantswarm/coredns-app/compare/v1.4.0...v1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,7 +235,8 @@ data:
 
 - Remove `proxy` configuration support as it is [deprecated by upstream](https://coredns.io/2019/03/03/coredns-1.4.0-release/). New server block with `forward` plugin has to be used, more info in our [docs](https://docs.giantswarm.io/guides/advanced-coredns-configuration/).
 
-[Unreleased]: https://github.com/giantswarm/coredns-app/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/giantswarm/coredns-app/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/giantswarm/coredns-app/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/giantswarm/coredns-app/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/giantswarm/coredns-app/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/giantswarm/coredns-app/compare/v1.4.0...v1.4.1

--- a/helm/coredns-app/templates/deployment-masters.yaml
+++ b/helm/coredns-app/templates/deployment-masters.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}-cp
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+  selector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Values.ports.prometheus }}"
+        giantswarm.io/monitoring-path: /metrics
+        giantswarm.io/monitoring-port: "{{ .Values.ports.prometheus }}"
+      labels:
+        {{- include "labels.common" . | nindent 8 }}
+        giantswarm.io/monitoring: "true"
+    spec:
+      serviceAccountName: {{ .Values.name }}
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsUser: {{ .Values.userID }}
+        runAsGroup: {{ .Values.groupID }}
+      tolerations:
+      - effect: NoSchedule
+        operator: "Exists"
+        key: node-role.kubernetes.io/master
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: k8s-app
+                    operator: In
+                    values:
+                    - {{ .Values.name }}
+              topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      containers:
+      - name: coredns
+        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        imagePullPolicy: IfNotPresent
+        args: [ "-conf", "/etc/coredns/Corefile", "-dns.port", "1053" ]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+        # We need to create the /tmp folder to avoid CoreDNS crash when api-server is down
+        - mountPath: /tmp/
+          name: temp-volume
+        ports:
+        - containerPort: {{ .Values.ports.dns.targetPort }}
+          name: {{ .Values.ports.dns.name }}
+          protocol: UDP
+        - containerPort: {{ .Values.ports.dns.targetPort }}
+          name: {{ .Values.ports.dns.name }}-tcp
+          protocol: TCP
+      {{- if .Values.resources }}
+        resources: {{ toYaml .Values.resources | nindent 10 }}
+      {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 7
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8181
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+      dnsPolicy: Default
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ .Values.name }}
+            items:
+            - key: Corefile
+              path: Corefile
+        # We need to create the /tmp folder to avoid CoreDNS crash during api-server is down
+        - emptyDir: {}
+          name: temp-volume

--- a/helm/coredns-app/templates/deployment-workers.yaml
+++ b/helm/coredns-app/templates/deployment-workers.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-np
+  name: {{ .Values.name }}
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/coredns-app/templates/deployment-workers.yaml
+++ b/helm/coredns-app/templates/deployment-workers.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}
+  name: {{ .Values.name }}-np
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -29,10 +29,6 @@ spec:
       securityContext:
         runAsUser: {{ .Values.userID }}
         runAsGroup: {{ .Values.groupID }}
-      tolerations:
-      - effect: NoSchedule
-        operator: "Exists"
-        key: node-role.kubernetes.io/master
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/helm/coredns-app/templates/deployment.yaml
+++ b/helm/coredns-app/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       securityContext:
         runAsUser: {{ .Values.userID }}
         runAsGroup: {{ .Values.groupID }}
+      tolerations:
+      - effect: NoSchedule
+        operator: "Exists"
+        key: node-role.kubernetes.io/master
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
See https://gigantic.slack.com/archives/C02HLSDH3DZ/p1640189730358700 and https://gigantic.slack.com/archives/C02HLSDH3DZ/p1640192376360300

In AWS, cluster autoscaler requires to resolve public host names to start, or it errors and pages.
For clusters without worker nodes, coredns can't be scheduled and thus the above error happens.
We believe that coredns is such a fundamental component of a kubernetes cluster that it should be allowed to run in the master nodes as well as a last resort if there are no worker nodes in the cluster.

This PR adds a toleration to allow scheduling coredns pods in master nodes.