### PR TITLE
Added CAPI feature flag

### DIFF
--- a/helm/coredns-app/templates/deployment-masters.yaml
+++ b/helm/coredns-app/templates/deployment-masters.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.isCAPI }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -105,3 +106,4 @@ spec:
         # We need to create the /tmp folder to avoid CoreDNS crash during api-server is down
         - emptyDir: {}
           name: temp-volume
+{{- end }}

--- a/helm/coredns-app/templates/deployment-workers.yaml
+++ b/helm/coredns-app/templates/deployment-workers.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.isCAPI }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -99,3 +100,4 @@ spec:
         # We need to create the /tmp folder to avoid CoreDNS crash during api-server is down
         - emptyDir: {}
           name: temp-volume
+{{- end }}

--- a/helm/coredns-app/templates/service.yaml
+++ b/helm/coredns-app/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.isCAPI }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
     port: {{ .Values.ports.dns.port }}
     targetPort: {{ .Values.ports.dns.targetPort }}
     protocol: TCP
+{{- end }}

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -6,6 +6,11 @@ name: coredns
 namespace: kube-system
 serviceType: managed
 
+# isCAPI indicates if the cluster being deployed into is
+# a cluster-api cluster which already manages core-dns.
+# If set to true we'll only manage config, PSPs and networkpolicy.
+isCAPI: false
+
 userID: 33
 groupID: 33
 


### PR DESCRIPTION
If deploying to a CAPI cluster where coredns is managed by kubeadm we have this app only adopt the resources required (pretty much everything except the deployments)