### PR TITLE
Add toleration for `node.cloudprovider.kubernetes.io/uninitialized`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add toleration for `node.cloudprovider.kubernetes.io/uninitialized`.
+
 ## [1.8.0] - 2022-01-20
 
 ### Changed

--- a/helm/coredns-app/templates/deployment-masters.yaml
+++ b/helm/coredns-app/templates/deployment-masters.yaml
@@ -33,6 +33,8 @@ spec:
       - effect: NoSchedule
         operator: "Exists"
         key: node-role.kubernetes.io/master
+      - operator: "Exists"
+        key: "node.cloudprovider.kubernetes.io/uninitialized"
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/helm/coredns-app/templates/deployment-workers.yaml
+++ b/helm/coredns-app/templates/deployment-workers.yaml
@@ -29,6 +29,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.userID }}
         runAsGroup: {{ .Values.groupID }}
+      tolerations:
+      - operator: "Exists"
+        key: "node.cloudprovider.kubernetes.io/uninitialized"
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/888

When using `cloud-provider: external` in the kubelet makes nodes have a `node.cloudprovider.kubernetes.io/uninitialized` taint until the external cloud controller manager runs and removes it.
When creating a new cluster from scratch, all nodes are tainted that way and thus most pods can't be scheduled.
Unfortunately, the `AWS cloud controller manager` needs coredns in order to work, so we need to make the coredns app tolerate the `node.cloudprovider.kubernetes.io/uninitialized` taint in order to start.

A classic chicken-egg problem.

This PR does just that.