### PR TITLE
Fix deployment selectors to avoid duplicate matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct pod selectors on each deployment. Deployments renamed to allow for changing the selectors.
+
 ## [1.9.0] - 2022-04-11
 
 ### Added
@@ -16,7 +20,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Update `coredns` to upstream version [1.8.7](https://coredns.io/2021/12/09/coredns-1.8.7-release/).
- 
+
 ## [1.8.0] - 2022-01-20
 
 ### Changed

--- a/helm/coredns-app/templates/deployment-masters.yaml
+++ b/helm/coredns-app/templates/deployment-masters.yaml
@@ -12,7 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
-      app.kubernetes.io/component: control-plane
+      target: control-plane
   template:
     metadata:
       annotations:
@@ -23,7 +23,7 @@ spec:
         giantswarm.io/monitoring-port: "{{ .Values.ports.prometheus }}"
       labels:
         {{- include "labels.common" . | nindent 8 }}
-        app.kubernetes.io/component: control-plane
+        target: control-plane
         giantswarm.io/monitoring: "true"
     spec:
       serviceAccountName: {{ .Values.name }}

--- a/helm/coredns-app/templates/deployment-masters.yaml
+++ b/helm/coredns-app/templates/deployment-masters.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}-cp
+  name: {{ .Values.name }}-controlplane
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: control-plane
   template:
     metadata:
       annotations:
@@ -22,6 +23,7 @@ spec:
         giantswarm.io/monitoring-port: "{{ .Values.ports.prometheus }}"
       labels:
         {{- include "labels.common" . | nindent 8 }}
+        app.kubernetes.io/component: control-plane
         giantswarm.io/monitoring: "true"
     spec:
       serviceAccountName: {{ .Values.name }}

--- a/helm/coredns-app/templates/deployment-workers.yaml
+++ b/helm/coredns-app/templates/deployment-workers.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}
+  name: {{ .Values.name }}-workers
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+      app.kubernetes.io/component: workers
   template:
     metadata:
       annotations:
@@ -22,6 +23,7 @@ spec:
         giantswarm.io/monitoring-port: "{{ .Values.ports.prometheus }}"
       labels:
         {{- include "labels.common" . | nindent 8 }}
+        app.kubernetes.io/component: workers
         giantswarm.io/monitoring: "true"
     spec:
       serviceAccountName: {{ .Values.name }}

--- a/helm/coredns-app/templates/deployment-workers.yaml
+++ b/helm/coredns-app/templates/deployment-workers.yaml
@@ -12,7 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
-      app.kubernetes.io/component: workers
+      target: workers
   template:
     metadata:
       annotations:
@@ -23,7 +23,7 @@ spec:
         giantswarm.io/monitoring-port: "{{ .Values.ports.prometheus }}"
       labels:
         {{- include "labels.common" . | nindent 8 }}
-        app.kubernetes.io/component: workers
+        target: workers
         giantswarm.io/monitoring: "true"
     spec:
       serviceAccountName: {{ .Values.name }}

--- a/helm/coredns-app/templates/hpa.yaml
+++ b/helm/coredns-app/templates/hpa.yaml
@@ -10,5 +10,5 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: coredns
+    name: coredns-workers
   targetCPUUtilizationPercentage: {{ .Values.hpa.targetCPUUtilizationPercentage }}


### PR DESCRIPTION
Both deployments were using the same selector so matching all coredns pods.

As selectors are immutable, a slight change to the deployment names was needed to have them recreated new.