### PR TITLE
Allow setting the scale down behaviour

### DIFF
--- a/helm/coredns-app/templates/hpa.yaml
+++ b/helm/coredns-app/templates/hpa.yaml
@@ -14,4 +14,4 @@ spec:
   targetCPUUtilizationPercentage: {{ .Values.hpa.targetCPUUtilizationPercentage }}
   behavior:
     scaleDown:
-      stabilizationWindowSeconds: {{ .Values.hpa.scaleDownStabilizationWindowSeconds }}
+      stabilizationWindowSeconds: {{ .Values.hpa.behavior.scaleDown.stabilizationWindowSeconds }}

--- a/helm/coredns-app/templates/hpa.yaml
+++ b/helm/coredns-app/templates/hpa.yaml
@@ -12,3 +12,6 @@ spec:
     kind: Deployment
     name: coredns-workers
   targetCPUUtilizationPercentage: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.hpa.scaleDownStabilizationWindowSeconds }}

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -13,12 +13,12 @@ hpa:
   minReplicas: 2
   maxReplicas: 50
   targetCPUUtilizationPercentage: 70
-  # The stabilization window is used to restrict the flapping of replica count 
+  # The stabilization window is used to restrict the flapping of replica count
   # when the metrics used for scaling keep fluctuating.
   # This is very useful for large scale clusters to prevent the CoreDNS from flapping
   # while kube-proxy is taking long time to add th scaled up pods to the service
   # In such cases set this value to at least 1800
-  scaleDownStabilizationWindowSeconds: 600  
+  scaleDownStabilizationWindowSeconds: 600
 
 configmap:
 # Uncomment "autopath" to enable DNS autopath https://coredns.io/plugins/autopath/

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -16,11 +16,11 @@ hpa:
   # The stabilization window is used to restrict the flapping of replica count
   # when the metrics used for scaling keep fluctuating.
   # This is very useful for large scale clusters to prevent the CoreDNS from flapping
-  # while kube-proxy is taking long time to add th scaled up pods to the service
+  # while kube-proxy is taking long time to add the scaled up pods to the service
   # In such cases set this value to at least 1800
   behavior:
     scaleDown:
-      stabilizationWindowSeconds: 600
+      stabilizationWindowSeconds: 300
 
 configmap:
 # Uncomment "autopath" to enable DNS autopath https://coredns.io/plugins/autopath/

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -17,8 +17,10 @@ hpa:
   # when the metrics used for scaling keep fluctuating.
   # This is very useful for large scale clusters to prevent the CoreDNS from flapping
   # while kube-proxy is taking long time to add th scaled up pods to the service
-  # In such cases set this value to at least 1800
-  scaleDownStabilizationWindowSeconds: 600
+  # In such cases set this value to at least 1800  
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 600
 
 configmap:
 # Uncomment "autopath" to enable DNS autopath https://coredns.io/plugins/autopath/

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -13,6 +13,12 @@ hpa:
   minReplicas: 2
   maxReplicas: 50
   targetCPUUtilizationPercentage: 70
+  # The stabilization window is used to restrict the flapping of replica count 
+  # when the metrics used for scaling keep fluctuating.
+  # This is very useful for large scale clusters to prevent the CoreDNS from flapping
+  # while kube-proxy is taking long time to add th scaled up pods to the service
+  # In such cases set this value to at least 1800
+  scaleDownStabilizationWindowSeconds: 600  
 
 configmap:
 # Uncomment "autopath" to enable DNS autopath https://coredns.io/plugins/autopath/

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -17,7 +17,7 @@ hpa:
   # when the metrics used for scaling keep fluctuating.
   # This is very useful for large scale clusters to prevent the CoreDNS from flapping
   # while kube-proxy is taking long time to add th scaled up pods to the service
-  # In such cases set this value to at least 1800  
+  # In such cases set this value to at least 1800
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 600


### PR DESCRIPTION
The stabilization window is used to restrict the [flapping](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#flapping) of replica count when the metrics used for scaling keep fluctuating