### PR TITLE
Allow customization of nodeselector for CoreDNS Master Instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- `values.schema.json` file
+
 ### Changed
 
 - Move nodeselector `label:value` to values.yaml to allow customizing it for CAPZ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Move nodeselector `label:value` to values.yaml to allow customizing it for CAPZ
+- Add toleration for `node-role.kubernetes.io/control-plane` to masters instance
+
 ## [1.12.0] - 2022-11-30
 
 ### Added

--- a/helm/coredns-app/templates/deployment-masters.yaml
+++ b/helm/coredns-app/templates/deployment-masters.yaml
@@ -36,6 +36,9 @@ spec:
       - effect: NoSchedule
         operator: "Exists"
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        operator: "Exists"
+        key: node-role.kubernetes.io/control-plane
       - operator: "Exists"
         key: "node.cloudprovider.kubernetes.io/uninitialized"
       affinity:
@@ -51,7 +54,9 @@ spec:
                     - {{ .Values.name }}
               topologyKey: kubernetes.io/hostname
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        {{-  range $key, $value := $.Values.mastersInstance.nodeSelector }}
+        {{ $key }}: {{ $value }}
+        {{- end}}
       containers:
       - name: coredns
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/helm/coredns-app/values.schema.json
+++ b/helm/coredns-app/values.schema.json
@@ -1,0 +1,207 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "cluster": {
+            "type": "object",
+            "properties": {
+                "calico": {
+                    "type": "object",
+                    "properties": {
+                        "CIDR": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "kubernetes": {
+                    "type": "object",
+                    "properties": {
+                        "API": {
+                            "type": "object",
+                            "properties": {
+                                "clusterIPRange": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "DNS": {
+                            "type": "object",
+                            "properties": {
+                                "IP": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "clusterDomain": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "configmap": {
+            "type": "object",
+            "properties": {
+                "cache": {
+                    "type": "integer"
+                },
+                "custom": {
+                    "type": "string"
+                },
+                "log": {
+                    "type": "string"
+                }
+            }
+        },
+        "groupID": {
+            "type": "integer"
+        },
+        "hpa": {
+            "type": "object",
+            "properties": {
+                "behavior": {
+                    "type": "object",
+                    "properties": {
+                        "scaleDown": {
+                            "type": "object",
+                            "properties": {
+                                "stabilizationWindowSeconds": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "maxReplicas": {
+                    "type": "integer"
+                },
+                "minReplicas": {
+                    "type": "integer"
+                },
+                "targetCPUUtilizationPercentage": {
+                    "type": "integer"
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "loadbalancePolicy": {
+            "type": "string"
+        },
+        "mastersInstance": {
+            "type": "object",
+            "properties": {
+                "nodeSelector": {
+                    "type": "object",
+                    "properties": {
+                        "node-role.kubernetes.io/master": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "name": {
+            "type": "string"
+        },
+        "namespace": {
+            "type": "string"
+        },
+        "ports": {
+            "type": "object",
+            "properties": {
+                "dns": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "prometheus": {
+                    "type": "integer"
+                }
+            }
+        },
+        "resources": {
+            "type": "object",
+            "properties": {
+                "limits": {
+                    "type": "object",
+                    "properties": {
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "requests": {
+                    "type": "object",
+                    "properties": {
+                        "cpu": {
+                            "type": "string"
+                        },
+                        "memory": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "serviceType": {
+            "type": "string"
+        },
+        "test": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "rollingUpdate": {
+                    "type": "object",
+                    "properties": {
+                        "maxUnavailable": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "userID": {
+            "type": "integer"
+        }
+    }
+}

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -72,6 +72,10 @@ cluster:
 
 loadbalancePolicy: round_robin
 
+mastersInstance:
+  nodeSelector:
+    "node-role.kubernetes.io/master": '""'
+
 test:
   image:
     name: giantswarm/alpine-testing


### PR DESCRIPTION
This is needed in CAPZ since the master instnaces do not have the label currently used

since i could not see any map in the values.yaml dedicated to the mastersInstance i added one but if you think it should be placed somewhere else i can move it.

---

**Diff between previous release and this one**

Only adding one toleration to the `masters instance` of coredns

```
➜ diff -u /tmp/coredns-master.yaml /tmp/coredns-branch-old.yaml
--- /tmp/coredns-master.yaml    2022-12-21 17:35:35.682676042 +0100
+++ /tmp/coredns-branch-old.yaml        2022-12-21 17:38:54.664938822 +0100
@@ -385,6 +385,9 @@
       - effect: NoSchedule
         operator: "Exists"
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        operator: "Exists"
+        key: node-role.kubernetes.io/control-plane
       - operator: "Exists"
         key: "node.cloudprovider.kubernetes.io/uninitialized"
       affinity:
```

---
**Diff when using capz flags**

Add toleration and replace nodeselector

```
➜ cat /dev/shm/coredns-capz-values.yaml 
mastersInstance:
  nodeSelector:
    "node-role.kubernetes.io/master": null
    "node-role.kubernetes.io/control-plane": '""'

➜ diff -u /tmp/coredns-master.yaml /tmp/coredns-branch-capz.yaml
--- /tmp/coredns-master.yaml    2022-12-21 17:35:35.682676042 +0100
+++ /tmp/coredns-branch-capz.yaml       2022-12-21 17:42:11.174148982 +0100
@@ -385,6 +385,9 @@
       - effect: NoSchedule
         operator: "Exists"
         key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        operator: "Exists"
+        key: node-role.kubernetes.io/control-plane
       - operator: "Exists"
         key: "node.cloudprovider.kubernetes.io/uninitialized"
       affinity:
@@ -400,7 +403,7 @@
                     - coredns
               topologyKey: kubernetes.io/hostname
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       containers:
       - name: coredns
         image: "docker.io/giantswarm/coredns:1.9.3"

```