### PR TITLE
Add lameduck to health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- ConfigMap: Add lameduck of 5 seconds to health check ([#190](https://github.com/giantswarm/coredns-app/pull/190)).
+
 ## [1.14.1] - 2023-02-14
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- ConfigMap: Add lameduck of 5 seconds to health check ([#190](https://github.com/giantswarm/coredns-app/pull/190)).
+- ConfigMap: Add lameduck of 5 seconds to health check ([#191](https://github.com/giantswarm/coredns-app/pull/191)).
 
 ## [1.14.1] - 2023-02-14
 

--- a/helm/coredns-app/templates/configmap.yaml
+++ b/helm/coredns-app/templates/configmap.yaml
@@ -12,7 +12,9 @@ data:
         cache {{ .Values.configmap.cache }}
         {{- end }}
         errors
-        health
+        health {
+          lameduck 5s
+        }
         ready
         kubernetes {{ .Values.cluster.kubernetes.clusterDomain }} {{ .Values.cluster.kubernetes.API.clusterIPRange }} {{ .Values.cluster.calico.CIDR }} {
           fallthrough in-addr.arpa ip6.arpa


### PR DESCRIPTION
- Add lameduck of 5s to health block following upstream default value
- update changelog

Following upstream https://github.com/coredns/deployment/issues/199, this change should improve reliability during rollouts.