### PR TITLE
Fix kubernetes version for node selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix controlplane label in Kubernetes 1.24.
+
 ## [1.15.0] - 2023-03-30
 
 ### Added

--- a/helm/coredns-app/templates/deployment-masters.yaml
+++ b/helm/coredns-app/templates/deployment-masters.yaml
@@ -55,8 +55,8 @@ spec:
               topologyKey: kubernetes.io/hostname
       nodeSelector:
         {{-  range $key, $value := $.Values.mastersInstance.nodeSelector }}
-          {{- if and (eq $key "node-role.kubernetes.io/control-plane") (semverCompare "<1.25" $.Capabilities.KubeVersion.Version) }}
-            # node-role.kubernets.io/master is deprecated and removed in v1.25 of kubeadm however, we still need to support clusters with older versions.
+          {{- if and (eq $key "node-role.kubernetes.io/control-plane") (semverCompare "<1.24" $.Capabilities.KubeVersion.Version) }}
+            # node-role.kubernets.io/master is deprecated and removed in v1.24 of kubeadm however, we still need to support clusters with older versions.
             node-role.kubernetes.io/master: ""
           {{- else }}
             {{ $key }}: {{ $value }}


### PR DESCRIPTION
The `master` label was removed in 1.24, not 1.25.

https://kubernetes.io/blog/2022/04/07/upcoming-changes-in-kubernetes-1-24/#api-removals-deprecations-and-other-changes-for-kubernetes-1-24

https://github.com/giantswarm/cloud-provider-cloud-director-app/pull/43#discussion_r1157374156