### PR TITLE
Expose http-metrics port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add `http-metrics` port to the list of exposed ports so Prometheus can access container metadata (e.g. `__meta_kubernetes_pod_container_xxx`).
+
 ## [1.15.1] - 2023-04-05
 
 ### Fixed

--- a/helm/coredns-app/templates/deployment-masters.yaml
+++ b/helm/coredns-app/templates/deployment-masters.yaml
@@ -88,6 +88,9 @@ spec:
         - containerPort: {{ .Values.ports.dns.targetPort }}
           name: {{ .Values.ports.dns.name }}-tcp
           protocol: TCP
+        - containerPort: {{ .Values.ports.prometheus }}
+          name: http-metrics
+          protocol: TCP
       {{- if .Values.resources }}
         resources: {{ toYaml .Values.resources | nindent 10 }}
       {{- end }}

--- a/helm/coredns-app/templates/deployment-workers.yaml
+++ b/helm/coredns-app/templates/deployment-workers.yaml
@@ -72,6 +72,9 @@ spec:
         - containerPort: {{ .Values.ports.dns.targetPort }}
           name: {{ .Values.ports.dns.name }}-tcp
           protocol: TCP
+        - containerPort: {{ .Values.ports.prometheus }}
+          name: http-metrics
+          protocol: TCP
       {{- if .Values.resources }}
         resources: {{ toYaml .Values.resources | nindent 10 }}
       {{- end }}


### PR DESCRIPTION
Coming from https://github.com/giantswarm/prometheus-operator-app/pull/256 I noticed that when prometheus access metrics from a port not exposed in the pod definition, it cannot access container metadata like ports and the container name. 

This PR adds the prometheus port to the list of defined ports so Prometheus can access the data it needs.

cc @giantswarm/team-atlas 