### PR TITLE
Decouple PDB from updateStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add scaling based on custom metrics ([#209](https://github.com/giantswarm/coredns-app/pull/209)).
 
+### Changed
+
+- Decouple PDB configuration from deployment updateStrategy ([#208](https://github.com/giantswarm/coredns-app/pull/208)).
+
 ## [1.16.0] - 2023-05-04
 
 ### Changed

--- a/helm/coredns-app/templates/pdb.yaml
+++ b/helm/coredns-app/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if (gt (.Values.hpa.maxReplicas | int) 1) }}
+{{- if and (gt (.Values.hpa.maxReplicas | int) 1) .Values.podDisruptionBudget -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -7,8 +7,8 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
-  maxUnavailable: {{ .Values.updateStrategy.rollingUpdate.maxUnavailable }}
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
 {{- end }}

--- a/helm/coredns-app/values.schema.json
+++ b/helm/coredns-app/values.schema.json
@@ -86,6 +86,9 @@
                 },
                 "targetCPUUtilizationPercentage": {
                     "type": "integer"
+                },
+                "targetMemoryUtilizationPercentage": {
+                    "type": "integer"
                 }
             }
         },
@@ -124,6 +127,14 @@
         },
         "namespace": {
             "type": "string"
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "properties": {
+                "maxUnavailable": {
+                    "type": "string"
+                }
+            }
         },
         "ports": {
             "type": "object",

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -47,7 +47,10 @@ image:
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:
-    maxUnavailable: 25%
+    maxUnavailable: 1
+
+podDisruptionBudget:
+  maxUnavailable: 25%
 
 ports:
   dns:


### PR DESCRIPTION
PDB and updateStrategy are using the same values. Not long ago, to give some air to the node rotation, maxUnavailable was increased to 25%.

That change affected both PDB (desired) and the updateStrategy of the deployment (side effect). 

This PR decouples the config creating a specific value for PDB and rolls back the updateStrategy to its former value. 