### PR TITLE
Remove deprecated giant swarm monitoring labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Update `architect-orb` to 5.1.0.
 
+### Removed
+
+- Removed legacy Giant Swarm monitoring labels as coredns is monitored through a prometheus-operator generated servicemonitor.
+
 ## [1.21.0] - 2024-01-09
 
 ### Changed

--- a/helm/coredns-app/templates/deployment-masters.yaml
+++ b/helm/coredns-app/templates/deployment-masters.yaml
@@ -20,11 +20,8 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.ports.prometheus }}"
-        giantswarm.io/monitoring-path: /metrics
-        giantswarm.io/monitoring-port: "{{ .Values.ports.prometheus }}"
       labels:
         {{- include "labels.common" . | nindent 8 }}
-        giantswarm.io/monitoring: "true"
         app.kubernetes.io/component: control-plane
     spec:
       serviceAccountName: {{ .Values.name }}

--- a/helm/coredns-app/templates/deployment-workers.yaml
+++ b/helm/coredns-app/templates/deployment-workers.yaml
@@ -19,11 +19,8 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.ports.prometheus }}"
-        giantswarm.io/monitoring-path: /metrics
-        giantswarm.io/monitoring-port: "{{ .Values.ports.prometheus }}"
       labels:
         {{- include "labels.common" . | nindent 8 }}
-        giantswarm.io/monitoring: "true"
         app.kubernetes.io/component: workers
     spec:
       serviceAccountName: {{ .Values.name }}


### PR DESCRIPTION
This PR removes the deprecated Giant Swarm monitoring labels