### PR TITLE
CoreDNS 1.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update `coredns` image to [1.12.2](https://github.com/coredns/coredns/releases/tag/v1.12.2).
+
 ## [1.25.0] - 2025-04-02
 
 ### Changed

--- a/helm/coredns-app/Chart.yaml
+++ b/helm/coredns-app/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   application.giantswarm.io/team: cabbage
 apiVersion: v2
-appVersion: 1.12.1
+appVersion: 1.12.2
 description: A Helm chart for CoreDNS
 home: https://github.com/giantswarm/coredns-app
 icon: https://s.giantswarm.io/app-icons/coredns/1/dark.svg

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -42,7 +42,7 @@ configmap:
 image:
   registry: gsoci.azurecr.io
   name: giantswarm/coredns
-  tag: 1.12.1
+  tag: 1.12.2
 
 updateStrategy:
   type: RollingUpdate


### PR DESCRIPTION
<!--
@team-cabbage will automatically be requested for review once this PR has been submitted.
-->

This PR:

- Updates `coredns` image to [1.12.2](https://github.com/coredns/coredns/releases/tag/v1.12.2).

---

## Checklist

- [x] I added a CHANGELOG entry
- [ ] I ran E2E tests in the CI pipelines

Add the following comment to trigger the E2E tests:

`/run app-test-suites`
