### PR TITLE
Add value to toggle creation of controlplane deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add value to toggle creation of controlplane deployment.
+
 ## [1.28.0] - 2025-10-06
 
 ### Changed

--- a/helm/coredns-app/templates/deployment-masters.yaml
+++ b/helm/coredns-app/templates/deployment-masters.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mastersInstance.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -130,3 +131,4 @@ spec:
         # We need to create the /tmp folder to avoid CoreDNS crash during api-server is down
         - emptyDir: {}
           name: temp-volume
+{{- end }}

--- a/helm/coredns-app/values.schema.json
+++ b/helm/coredns-app/values.schema.json
@@ -119,6 +119,10 @@
                             "type": "string"
                         }
                     }
+                },
+                "enabled": {
+                    "type": "boolean",
+                    "default": true
                 }
             }
         },

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -79,6 +79,7 @@ cluster:
 loadbalancePolicy: round_robin
 
 mastersInstance:
+  enabled: true
   nodeSelector:
     "node-role.kubernetes.io/control-plane": '""'
 


### PR DESCRIPTION
<!--
@team-cabbage will automatically be requested for review once this PR has been submitted.
-->

This PR:

- adds a value which can toggle creation of the controlplane deployment (defaults to enabled for backwards compatibility)
---

## Checklist

- [x] I added a CHANGELOG entry
- [x] I ran E2E tests in the CI pipelines

Add the following comment to trigger the E2E tests:

`/run app-test-suites`
