### PR TITLE
Update coredns image to 1.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update `coredns` image to [1.14.3](https://github.com/coredns/coredns/releases/tag/v1.14.3).
+
 ## [1.30.0] - 2026-04-01
 
 ### Added

--- a/helm/coredns-app/Chart.yaml
+++ b/helm/coredns-app/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   io.giantswarm.application.team: cabbage
   io.giantswarm.application.audience: "all"
 apiVersion: v2
-appVersion: 1.14.2
+appVersion: 1.14.3
 description: A Helm chart for CoreDNS
 home: https://github.com/giantswarm/coredns-app
 icon: https://s.giantswarm.io/app-icons/coredns/1/dark.svg

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -42,7 +42,7 @@ configmap:
 image:
   registry: gsoci.azurecr.io
   name: giantswarm/coredns
-  tag: 1.14.2
+  tag: 1.14.3
 
 updateStrategy:
   type: RollingUpdate


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

<!--
@team-cabbage will automatically be requested for review once this PR has been submitted.
-->

This PR:

- CoreDNS image to 1.14.3

Towards https://github.com/giantswarm/giantswarm/issues/36494

---

## Checklist

- [x] I added a CHANGELOG entry
- [ ] I ran E2E tests in the CI pipelines

Add the following comment to trigger the E2E tests:

`/run app-test-suites`
