### PR TITLE
feat(helm): wire up full forward, cache and kubernetes block parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Wire up the full set of CoreDNS `forward`, `cache`, and `kubernetes` block parameters in the structured zone config:
+  - `forward`: `maxIdleConns`, `maxConnectAttempts`, `dohMethod`, `tls`, `tlsServername`, `next`, `nextOnNodata`, `failfastAllUnhealthyUpstreams`, `failover`, `resolver`.
+  - `cache`: `zones`, `serveStale.verifyTimeout`, `disable.successZones`, `disable.denialZones`.
+  - `kubernetes`: `endpoint`, `tls`, `kubeconfig`, `apiserverQPS`, `apiserverBurst`, `apiserverMaxInflight`, `namespaceLabels`, `fallthroughZones`, `multicluster`, `startupTimeout`.
+
 ### Fixed
 
 - Render the `health` directive in only the `.` server block. The health plugin is process-wide and can be enabled in just one Server Block, so emitting it in every zone block was invalid. `ready` is kept in every block (its readiness is aggregated across blocks).
+- Correct the `coredns.*.cache.serveStale.refreshMode` schema enum to `immediate`/`verify` (was `immediate`/`background`), matching the CoreDNS cache plugin.
 
 ### Refactored
 

--- a/helm/coredns-app/ci/test-cache-block-values.yaml
+++ b/helm/coredns-app/ci/test-cache-block-values.yaml
@@ -1,0 +1,35 @@
+# Exercises the structured cache block parameters wired up from the CoreDNS
+# cache plugin README. Layered on top of ci-values.yaml by the render-diff CI.
+coredns:
+  public:
+    cache:
+      ttl: 30
+      zones:
+        - example.org
+      success:
+        capacity: 5000
+        ttl: 30
+        minTTL: 5
+      denial:
+        capacity: 2500
+        ttl: 5
+        minTTL: 5
+      prefetch:
+        amount: 10
+        duration: 1m
+        percentage: 20
+      serveStale:
+        enabled: true
+        duration: 1h
+        refreshMode: verify
+        verifyTimeout: 100ms
+      servfail:
+        duration: 5s
+      disable:
+        success: true
+        successZones:
+          - a.example.org
+        denial: true
+        denialZones:
+          - b.example.org
+      keepttl: true

--- a/helm/coredns-app/ci/test-forward-block-values.yaml
+++ b/helm/coredns-app/ci/test-forward-block-values.yaml
@@ -1,0 +1,35 @@
+# Exercises the structured forward block parameters wired up from the CoreDNS
+# forward plugin README. Layered on top of ci-values.yaml by the render-diff CI.
+coredns:
+  public:
+    forward:
+      to:
+        - tls://9.9.9.9
+        - tls://1.1.1.1
+      except:
+        - example.org
+      forceTCP: true
+      preferUDP: true
+      expire: 10s
+      maxIdleConns: 5
+      maxFails: 2
+      maxConnectAttempts: 3
+      dohMethod: POST
+      tls:
+        cert: /etc/coredns/tls/cert.pem
+        key: /etc/coredns/tls/key.pem
+        ca: /etc/coredns/tls/ca.pem
+      tlsServername: dns.quad9.net
+      policy: sequential
+      healthCheck: 5s no_rec domain example.org
+      maxConcurrent: 1000
+      next:
+        - NXDOMAIN
+      nextOnNodata: true
+      failfastAllUnhealthyUpstreams: true
+      failover:
+        - SERVFAIL
+        - REFUSED
+      resolver:
+        - 10.0.0.1
+        - 10.0.0.2:5353

--- a/helm/coredns-app/ci/test-kubernetes-block-values.yaml
+++ b/helm/coredns-app/ci/test-kubernetes-block-values.yaml
@@ -1,0 +1,32 @@
+# Exercises the structured kubernetes block parameters wired up from the CoreDNS
+# kubernetes plugin README. Layered on top of ci-values.yaml by the render-diff CI.
+coredns:
+  cluster:
+    kubernetes:
+      pods: verified
+      endpoint: https://k8s-endpoint:8443
+      tls:
+        cert: /etc/coredns/tls/cert.pem
+        key: /etc/coredns/tls/key.pem
+        ca: /etc/coredns/tls/ca.pem
+      kubeconfig:
+        path: /etc/coredns/kubeconfig
+        context: default
+      apiserverQPS: 50
+      apiserverBurst: 100
+      apiserverMaxInflight: 10
+      ttl: 30
+      endpointPodNames: true
+      noendpoints: true
+      namespaces:
+        - test
+        - staging
+      namespaceLabels: istio-injection=enabled
+      labels: application=nginx
+      ignoreEmptyService: true
+      fallthroughZones:
+        - in-addr.arpa
+        - ip6.arpa
+      multicluster:
+        - clusterset.local
+      startupTimeout: 10s

--- a/helm/coredns-app/templates/_helpers.tpl
+++ b/helm/coredns-app/templates/_helpers.tpl
@@ -43,23 +43,23 @@ configmap.cache success-TTL seed.
 {{- $successTTL := coalesce $success.ttl .ctx.Values.configmap.cache | default 30 }}
 {{- $denialCapacity := $denial.capacity | default 9984 }}
 {{- $denialTTL := $denial.ttl | default 5 -}}
-cache{{- if $c.ttl }} {{ $c.ttl }}{{- end }} {
+cache{{- if $c.ttl }} {{ $c.ttl }}{{- end }}{{- with $c.zones }} {{ join " " . }}{{- end }} {
   success {{ $successCapacity }} {{ $successTTL }}{{- with $success.minTTL }} {{ . }}{{- end }}
   denial {{ $denialCapacity }} {{ $denialTTL }}{{- with $denial.minTTL }} {{ . }}{{- end }}
   {{- with $c.prefetch }}{{- if .amount }}
   prefetch {{ .amount }}{{- with .duration }} {{ . }}{{- end }}{{- with .percentage }} {{ . }}%{{- end }}
   {{- end }}{{- end }}
   {{- if and $c.serveStale $c.serveStale.enabled }}
-  serve_stale{{- with $c.serveStale.duration }} {{ . }}{{- end }}{{- with $c.serveStale.refreshMode }} {{ . }}{{- end }}
+  serve_stale{{- with $c.serveStale.duration }} {{ . }}{{- end }}{{- with $c.serveStale.refreshMode }} {{ . }}{{- with $c.serveStale.verifyTimeout }} {{ . }}{{- end }}{{- end }}
   {{- end }}
   {{- with $c.servfail }}{{- with .duration }}
   servfail {{ . }}
   {{- end }}{{- end }}
   {{- if and $c.disable $c.disable.success }}
-  disable success
+  disable success{{- with $c.disable.successZones }} {{ join " " . }}{{- end }}
   {{- end }}
   {{- if and $c.disable $c.disable.denial }}
-  disable denial
+  disable denial{{- with $c.disable.denialZones }} {{ join " " . }}{{- end }}
   {{- end }}
   {{- if $c.keepttl }}
   keepttl
@@ -84,14 +84,29 @@ the deprecated configmap.forward / configmap.forwardOptions strings consulted as
 {{- $upstreams := $f.to }}
 {{- if $upstreams }}
 {{- $lines := list }}
-{{- with $f.policy }}{{ $lines = append $lines (printf "policy %v" .) }}{{ end }}
+{{- with $f.except }}{{ $lines = append $lines (printf "except %s" (join " " .)) }}{{ end }}
 {{- if $f.forceTCP }}{{ $lines = append $lines "force_tcp" }}{{ end }}
 {{- if $f.preferUDP }}{{ $lines = append $lines "prefer_udp" }}{{ end }}
-{{- with $f.maxFails }}{{ $lines = append $lines (printf "max_fails %v" .) }}{{ end }}
-{{- with $f.healthCheck }}{{ $lines = append $lines (printf "health_check %v" .) }}{{ end }}
 {{- with $f.expire }}{{ $lines = append $lines (printf "expire %v" .) }}{{ end }}
+{{- with $f.maxIdleConns }}{{ $lines = append $lines (printf "max_idle_conns %v" .) }}{{ end }}
+{{- with $f.maxFails }}{{ $lines = append $lines (printf "max_fails %v" .) }}{{ end }}
+{{- with $f.maxConnectAttempts }}{{ $lines = append $lines (printf "max_connect_attempts %v" .) }}{{ end }}
+{{- with $f.dohMethod }}{{ $lines = append $lines (printf "doh_method %v" .) }}{{ end }}
+{{- with $f.tls }}
+{{- if and .cert .key .ca }}{{ $lines = append $lines (printf "tls %s %s %s" .cert .key .ca) }}
+{{- else if and .cert .key }}{{ $lines = append $lines (printf "tls %s %s" .cert .key) }}
+{{- else if .ca }}{{ $lines = append $lines (printf "tls %s" .ca) }}
+{{- else if .enabled }}{{ $lines = append $lines "tls" }}{{ end }}
+{{- end }}
+{{- with $f.tlsServername }}{{ $lines = append $lines (printf "tls_servername %v" .) }}{{ end }}
+{{- with $f.policy }}{{ $lines = append $lines (printf "policy %v" .) }}{{ end }}
+{{- with $f.healthCheck }}{{ $lines = append $lines (printf "health_check %v" .) }}{{ end }}
 {{- with $f.maxConcurrent }}{{ $lines = append $lines (printf "max_concurrent %v" .) }}{{ end }}
-{{- with $f.except }}{{ $lines = append $lines (printf "except %s" (join " " .)) }}{{ end }}
+{{- with $f.next }}{{ $lines = append $lines (printf "next %s" (join " " .)) }}{{ end }}
+{{- if $f.nextOnNodata }}{{ $lines = append $lines "next_on_nodata" }}{{ end }}
+{{- if $f.failfastAllUnhealthyUpstreams }}{{ $lines = append $lines "failfast_all_unhealthy_upstreams" }}{{ end }}
+{{- with $f.failover }}{{ $lines = append $lines (printf "failover %s" (join " " .)) }}{{ end }}
+{{- with $f.resolver }}{{ $lines = append $lines (printf "resolver %s" (join " " .)) }}{{ end }}
 {{- if and $compat (not $lines) .ctx.Values.configmap.forwardOptions }}
 {{- range (.ctx.Values.configmap.forwardOptions | trimAll "\n " | splitList "\n") }}{{ $lines = append $lines . }}{{ end }}
 {{- end -}}
@@ -128,27 +143,56 @@ values.yaml and values.schema.json.
 {{- $k := .zone.kubernetes | default dict -}}
 {{- $cidrs := join " " (.zone.cidrs | default list) -}}
 kubernetes {{ join " " .zone.names }}{{ with $cidrs }} {{ . }}{{ end }} {
-  pods {{ $k.pods | default "verified" }}
-  {{- with $k.ttl }}
-  ttl {{ . }}
+  {{- with $k.endpoint }}
+  endpoint {{ . }}
   {{- end }}
-  {{- if $k.endpointPodNames }}
-  endpoint_pod_names
+  {{- with $k.tls }}{{- if and .cert .key .ca }}
+  tls {{ .cert }} {{ .key }} {{ .ca }}
+  {{- end }}{{- end }}
+  {{- with $k.kubeconfig }}{{- with .path }}
+  kubeconfig {{ . }}{{- with $k.kubeconfig.context }} {{ . }}{{- end }}
+  {{- end }}{{- end }}
+  {{- with $k.apiserverQPS }}
+  apiserver_qps {{ . }}
   {{- end }}
-  {{- if $k.noendpoints }}
-  noendpoints
+  {{- with $k.apiserverBurst }}
+  apiserver_burst {{ . }}
+  {{- end }}
+  {{- with $k.apiserverMaxInflight }}
+  apiserver_max_inflight {{ . }}
   {{- end }}
   {{- with $k.namespaces }}
   namespaces {{ join " " . }}
   {{- end }}
+  {{- with $k.namespaceLabels }}
+  namespace_labels {{ . }}
+  {{- end }}
   {{- with $k.labels }}
   labels {{ . }}
+  {{- end }}
+  pods {{ $k.pods | default "verified" }}
+  {{- if $k.endpointPodNames }}
+  endpoint_pod_names
+  {{- end }}
+  {{- with $k.ttl }}
+  ttl {{ . }}
+  {{- end }}
+  {{- if $k.noendpoints }}
+  noendpoints
+  {{- end }}
+  {{- if $k.fallthroughZones }}
+  fallthrough {{ join " " $k.fallthroughZones }}
+  {{- else if $k.fallthrough }}
+  fallthrough
   {{- end }}
   {{- if $k.ignoreEmptyService }}
   ignore empty_service
   {{- end }}
-  {{- if $k.fallthrough }}
-  fallthrough
+  {{- with $k.multicluster }}
+  multicluster {{ join " " . }}
+  {{- end }}
+  {{- with $k.startupTimeout }}
+  startup_timeout {{ . }}
   {{- end }}
 }
 {{- end -}}

--- a/helm/coredns-app/values.schema.json
+++ b/helm/coredns-app/values.schema.json
@@ -10,6 +10,13 @@
                     "description": "Top-level TTL cap applied to all cached entries (seconds).",
                     "type": "integer"
                 },
+                "zones": {
+                    "description": "Zones the cache applies to (cache 'ZONES'). If empty, the zones from the server block are used.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "success": {
                     "description": "Configuration for caching positive (success) responses.",
                     "type": "object",
@@ -77,9 +84,13 @@
                             "type": "string"
                         },
                         "refreshMode": {
-                            "description": "Refresh mode for stale entries.",
+                            "description": "Refresh mode for stale entries. 'immediate' serves the stale entry before checking the source; 'verify' confirms the entry is still unavailable first.",
                             "type": "string",
-                            "enum": ["immediate", "background"]
+                            "enum": ["immediate", "verify"]
+                        },
+                        "verifyTimeout": {
+                            "description": "Only valid with refreshMode 'verify'. Bounds how long the cache waits for the upstream verify before falling back to the stale entry (e.g. 100ms). Default 0 waits for the upstream's own timeout.",
+                            "type": "string"
                         }
                     }
                 },
@@ -101,9 +112,23 @@
                             "description": "Disable caching of positive responses.",
                             "type": "boolean"
                         },
+                        "successZones": {
+                            "description": "Limit the success-cache disable to these zones (disable success 'ZONES'). Omit to disable for all zones.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
                         "denial": {
                             "description": "Disable caching of NXDOMAIN/NODATA responses.",
                             "type": "boolean"
+                        },
+                        "denialZones": {
+                            "description": "Limit the denial-cache disable to these zones (disable denial 'ZONES'). Omit to disable for all zones.",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     }
                 },
@@ -141,8 +166,47 @@
                     "description": "Consecutive failed health checks before an upstream is considered down (forward 'max_fails').",
                     "type": "integer"
                 },
+                "maxConnectAttempts": {
+                    "description": "Cap on total upstream connect attempts per request (forward 'max_connect_attempts'). 0 means no cap.",
+                    "type": "integer"
+                },
+                "maxIdleConns": {
+                    "description": "Maximum idle connections cached per upstream for reuse (forward 'max_idle_conns'). 0 means unlimited.",
+                    "type": "integer"
+                },
                 "healthCheck": {
-                    "description": "Upstream health-check configuration (forward 'health_check'), e.g. '0.2s' or '0.2s no_rec'.",
+                    "description": "Upstream health-check configuration (forward 'health_check'), e.g. '0.2s', '0.2s no_rec', or '5s domain example.org'.",
+                    "type": "string"
+                },
+                "dohMethod": {
+                    "description": "HTTP method for DoH requests (forward 'doh_method').",
+                    "type": "string",
+                    "enum": ["GET", "POST"]
+                },
+                "tls": {
+                    "description": "TLS configuration for the upstream connection (forward 'tls'). Provide cert+key (client auth), ca (custom server verification), all three, or set enabled for a bare 'tls' using system CAs.",
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "Emit a bare 'tls' directive (system CAs, no client auth) when no cert/key/ca are set.",
+                            "type": "boolean"
+                        },
+                        "cert": {
+                            "description": "Client certificate file path.",
+                            "type": "string"
+                        },
+                        "key": {
+                            "description": "Client key file path.",
+                            "type": "string"
+                        },
+                        "ca": {
+                            "description": "CA certificate file path used to verify the server certificate.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "tlsServername": {
+                    "description": "Server name expected in the upstream TLS certificate (forward 'tls_servername'), e.g. 'dns.quad9.net'. Strongly recommended when forwarding over TLS.",
                     "type": "string"
                 },
                 "expire": {
@@ -152,6 +216,35 @@
                 "maxConcurrent": {
                     "description": "Maximum number of concurrent queries to forward (forward 'max_concurrent').",
                     "type": "integer"
+                },
+                "next": {
+                    "description": "Response codes that cause the next forward plugin to be executed (forward 'next'), e.g. ['NXDOMAIN'].",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "nextOnNodata": {
+                    "description": "Execute the next forward plugin when the upstream returns NOERROR with an empty answer (forward 'next_on_nodata').",
+                    "type": "boolean"
+                },
+                "failfastAllUnhealthyUpstreams": {
+                    "description": "Immediately return SERVFAIL when all upstreams are unhealthy instead of spraying to a random upstream (forward 'failfast_all_unhealthy_upstreams').",
+                    "type": "boolean"
+                },
+                "failover": {
+                    "description": "Response codes that trigger a retry on the next upstream (forward 'failover'), e.g. ['SERVFAIL', 'REFUSED']. NOERROR is not allowed.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "resolver": {
+                    "description": "DNS resolver addresses used to resolve hostname-based 'to' endpoints at startup (forward 'resolver'), each a bare IP or IP:PORT.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "except": {
                     "description": "Domain names to pass through unforwarded (forward 'except').",
@@ -166,6 +259,54 @@
             "description": "Structured kubernetes plugin parameters, mirroring the CoreDNS kubernetes block. Only a representative subset is exposed; extend by adding keys here and in the coredns.kubernetesBlock helper.",
             "type": "object",
             "properties": {
+                "endpoint": {
+                    "description": "URL of a remote k8s API endpoint (kubernetes 'endpoint'). Omit to connect in-cluster. Ignored when kubeconfig is set.",
+                    "type": "string"
+                },
+                "tls": {
+                    "description": "TLS cert, key and CA cert file paths for a remote k8s connection (kubernetes 'tls'). Ignored when connecting in-cluster.",
+                    "type": "object",
+                    "properties": {
+                        "cert": {
+                            "description": "Client certificate file path.",
+                            "type": "string"
+                        },
+                        "key": {
+                            "description": "Client key file path.",
+                            "type": "string"
+                        },
+                        "ca": {
+                            "description": "CA certificate file path.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "kubeconfig": {
+                    "description": "Authenticate to a remote k8s cluster using a kubeconfig file (kubernetes 'kubeconfig').",
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "description": "Path to the kubeconfig file.",
+                            "type": "string"
+                        },
+                        "context": {
+                            "description": "Optional kubeconfig context. Defaults to the current context.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "apiserverQPS": {
+                    "description": "Maximum queries-per-second rate limit for API server requests (kubernetes 'apiserver_qps').",
+                    "type": "integer"
+                },
+                "apiserverBurst": {
+                    "description": "Maximum burst size for API server requests (kubernetes 'apiserver_burst').",
+                    "type": "integer"
+                },
+                "apiserverMaxInflight": {
+                    "description": "Maximum number of concurrent in-flight API server requests (kubernetes 'apiserver_max_inflight').",
+                    "type": "integer"
+                },
                 "pods": {
                     "description": "Pod A record handling mode (kubernetes 'pods').",
                     "type": "string",
@@ -190,6 +331,10 @@
                         "type": "string"
                     }
                 },
+                "namespaceLabels": {
+                    "description": "Expose only namespaces matching this label selector expression (kubernetes 'namespace_labels').",
+                    "type": "string"
+                },
                 "labels": {
                     "description": "Expose only objects matching this label selector expression (kubernetes 'labels').",
                     "type": "string"
@@ -199,8 +344,26 @@
                     "type": "boolean"
                 },
                 "fallthrough": {
-                    "description": "Pass unresolved queries to the next plugin (kubernetes 'fallthrough').",
+                    "description": "Pass unresolved queries to the next plugin for all authoritative zones (kubernetes 'fallthrough'). Ignored when fallthroughZones is set.",
                     "type": "boolean"
+                },
+                "fallthroughZones": {
+                    "description": "Limit fallthrough to these zones (kubernetes 'fallthrough ZONES'), e.g. ['in-addr.arpa', 'ip6.arpa'].",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "multicluster": {
+                    "description": "Multicluster zones served via the MCS-API (kubernetes 'multicluster'). The plugin must be authoritative for these zones.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "startupTimeout": {
+                    "description": "Time to wait for the informer cache to sync at startup (kubernetes 'startup_timeout'), e.g. '5s'.",
+                    "type": "string"
                 }
             }
         },

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -81,6 +81,7 @@ coredns:
   public:
     cache:
       # ttl: 30              # top-level TTL cap applied before success/denial checks
+      # zones: []            # cache ZONES... — limit caching to these zones (default: server-block zones)
       success:
         capacity: 9984       # max number of cached positive responses
         ttl: 30              # max TTL; defaults to configmap.cache for backward compat
@@ -96,23 +97,40 @@ coredns:
       serveStale:
         enabled: false       # serve stale answers while refreshing in background
         # duration: 1h       # how long stale answers may be served
-        # refreshMode: ""    # immediate | background
+        # refreshMode: ""    # immediate | verify
+        # verifyTimeout: 100ms # only with refreshMode verify — max wait for upstream verify before serving stale
       # servfail:
       #   duration: 5s       # how long to cache SERVFAIL responses
       # disable:
       #   success: false     # disable caching of positive responses
+      #   successZones: []   # disable success ZONES... — limit the disable to these zones
       #   denial: false      # disable caching of NXDOMAIN/NODATA responses
+      #   denialZones: []    # disable denial ZONES... — limit the disable to these zones
       # keepttl: false       # preserve original TTLs instead of counting down
     forward:
       to: []                # upstream DNS servers (the forward "TO..." targets); empty means use /etc/resolv.conf
-      # policy: random        # random | round_robin | sequential
+      # except: []            # except NAMES... — domains to pass through unforwarded
       # forceTCP: false       # force_tcp — always use TCP to the upstream
       # preferUDP: false      # prefer_udp — try UDP first even for queries received over TCP
-      # maxFails: 2           # max_fails — consecutive failed health checks before marking an upstream down
-      # healthCheck: 0.2s     # health_check DURATION [no_rec] [domain FQDN]
       # expire: 10s           # expire — close idle upstream connections after this duration
+      # maxIdleConns: 0       # max_idle_conns — idle connections cached per upstream (0 = unlimited)
+      # maxFails: 2           # max_fails — consecutive failed health checks before marking an upstream down
+      # maxConnectAttempts: 0 # max_connect_attempts — cap on connect attempts per request (0 = no cap)
+      # dohMethod: POST       # doh_method — GET | POST for DoH requests
+      # tls:                  # tls CERT KEY CA — set cert+key, ca, all three, or enabled for bare tls
+      #   enabled: false      #   emit bare "tls" (system CAs, no client auth)
+      #   cert: ""            #   client cert file path
+      #   key: ""             #   client key file path
+      #   ca: ""              #   CA cert file path
+      # tlsServername: ""     # tls_servername NAME — expected server cert name (e.g. dns.quad9.net)
+      # policy: random        # random | round_robin | sequential
+      # healthCheck: 0.2s     # health_check DURATION [no_rec] [domain FQDN]
       # maxConcurrent: 1000   # max_concurrent — maximum number of concurrent queries to forward
-      # except: []            # except NAMES... — domains to pass through unforwarded
+      # next: []              # next RCODE... — run next forward plugin on these rcodes (e.g. [NXDOMAIN])
+      # nextOnNodata: false   # next_on_nodata — run next forward plugin on empty NOERROR answers
+      # failfastAllUnhealthyUpstreams: false # failfast_all_unhealthy_upstreams — SERVFAIL when all down
+      # failover: []          # failover RCODE... — retry next upstream on these rcodes (e.g. [SERVFAIL, REFUSED])
+      # resolver: []          # resolver IP[:PORT]... — resolvers for hostname-based "to" endpoints
     log:                  # CoreDNS log classes for this zone; omit to fall back to denial+error
       - denial
       - error
@@ -126,6 +144,7 @@ coredns:
     # podCIDR: 192.168.0.0/16    # defaults to cluster.calico.CIDR; set coredns.cluster.podCIDR to override
     cache:
       # ttl: 30              # top-level TTL cap applied before success/denial checks
+      # zones: []            # cache ZONES... — limit caching to these zones (default: server-block zones)
       success:
         capacity: 9984       # max number of cached positive responses
         ttl: 30              # max TTL; defaults to configmap.cache for backward compat
@@ -141,25 +160,42 @@ coredns:
       serveStale:
         enabled: false       # serve stale answers while refreshing in background
         # duration: 1h
-        # refreshMode: ""    # immediate | background
+        # refreshMode: ""    # immediate | verify
+        # verifyTimeout: 100ms # only with refreshMode verify — max wait for upstream verify before serving stale
       # servfail:
       #   duration: 5s
       # disable:
       #   success: false
+      #   successZones: []
       #   denial: false
+      #   denialZones: []
       # keepttl: false
     # Structured kubernetes-plugin parameters, mirroring the CoreDNS kubernetes block
-    # (https://coredns.io/plugins/kubernetes/). Only a representative subset is wired up
-    # today; the block is designed to be extended one key at a time.
+    # (https://coredns.io/plugins/kubernetes/). Leave a key unset to keep the CoreDNS default.
     kubernetes:
       pods: verified              # pods — disabled | insecure | verified
+      # endpoint: ""              # endpoint URL — remote k8s API endpoint (omit for in-cluster)
+      # tls:                      # tls CERT KEY CACERT — for a remote k8s connection
+      #   cert: ""
+      #   key: ""
+      #   ca: ""
+      # kubeconfig:               # kubeconfig KUBECONFIG [CONTEXT] — authenticate via kubeconfig file
+      #   path: ""
+      #   context: ""
+      # apiserverQPS: 0           # apiserver_qps — max queries-per-second to the API server
+      # apiserverBurst: 0         # apiserver_burst — max burst size for API server requests
+      # apiserverMaxInflight: 0   # apiserver_max_inflight — max concurrent in-flight API server requests
       # ttl: 5                    # ttl SECONDS (0–3600)
       # endpointPodNames: false   # endpoint_pod_names — use pod name instead of dashed IP
       # noendpoints: false        # noendpoints — disable endpoint record serving
       # namespaces: []            # namespaces NAMESPACE... — expose only these namespaces
+      # namespaceLabels: ""       # namespace_labels EXPRESSION — expose only namespaces matching the selector
       # labels: ""                # labels EXPRESSION — expose only objects matching the selector
       # ignoreEmptyService: false # ignore empty_service — NXDOMAIN for services without ready endpoints
-      # fallthrough: false        # fallthrough — pass unresolved queries to the next plugin
+      # fallthrough: false        # fallthrough — pass unresolved queries to the next plugin (all zones)
+      # fallthroughZones: []      # fallthrough ZONES... — limit fallthrough to these zones
+      # multicluster: []          # multicluster ZONES... — MCS-API multicluster zones
+      # startupTimeout: 5s        # startup_timeout — wait for informer cache sync at startup
     log:                  # CoreDNS log classes for this zone; omit to fall back to denial+error
       - denial
       - error


### PR DESCRIPTION
## What

Extend the structured zone config and JSON schema so they cover **every** parameter documented in the CoreDNS `forward`, `cache`, and `kubernetes` plugin READMEs.

### forward
`max_idle_conns`, `max_connect_attempts`, `doh_method`, `tls`, `tls_servername`, `next`, `next_on_nodata`, `failfast_all_unhealthy_upstreams`, `failover`, `resolver`

### cache
`zones`, `serve_stale` verify timeout, per-type `disable` zones (`successZones` / `denialZones`)

### kubernetes
`endpoint`, `tls`, `kubeconfig`, `apiserver_qps` / `apiserver_burst` / `apiserver_max_inflight`, `namespace_labels`, `fallthrough` zones, `multicluster`, `startup_timeout`

## Also

- Add one `ci/test-*-values.yaml` per block exercising the new parameters (picked up automatically by the helm render-diff workflow).
- Correct the `coredns.*.cache.serveStale.refreshMode` schema enum to `immediate`/`verify` (was `immediate`/`background`).
- Document every new key in `values.yaml` and `values.schema.json`; CHANGELOG updated.

## Testing

- `helm template` renders unchanged for defaults.
- Each new CI values file renders valid CoreDNS directives when layered on `ci-values.yaml` (as the render-diff CI does).
- All existing CI value files still template cleanly.