### PR TITLE
docs(helm): standardize values.yaml comments for helm schema generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Standardize `values.yaml` comments to the `# @schema` / `# --` (helm-docs) convention and remove section-header dividers, so `values.schema.json` and the chart `README.md` are generated from the values file. Rendered manifests are unchanged.
+
 ### Added
 
 - Wire up the full set of CoreDNS `forward`, `cache`, and `kubernetes` block parameters in the structured zone config:

--- a/helm/coredns-app/README.md
+++ b/helm/coredns-app/README.md
@@ -1,6 +1,6 @@
 # coredns-app
 
-![Version: 1.30.1](https://img.shields.io/badge/Version-1.30.1-informational?style=flat-square) ![AppVersion: 1.14.3](https://img.shields.io/badge/AppVersion-1.14.3-informational?style=flat-square)
+![Version: 1.30.3](https://img.shields.io/badge/Version-1.30.3-informational?style=flat-square) ![AppVersion: 1.14.4](https://img.shields.io/badge/AppVersion-1.14.4-informational?style=flat-square)
 
 A Helm chart for CoreDNS
 
@@ -10,67 +10,191 @@ A Helm chart for CoreDNS
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| adopter.enabled | bool | `false` |  |
-| adopter.image | string | `"gsoci.azurecr.io/giantswarm/docker-kubectl:1.36.0"` |  |
-| cluster.calico.CIDR | string | `"192.168.0.0/16"` |  |
-| cluster.kubernetes.API.clusterIPRange | string | `"172.31.0.0/16"` |  |
-| cluster.kubernetes.DNS.IP | string | `"172.31.0.10"` |  |
-| cluster.kubernetes.clusterDomain | string | `"cluster.local"` |  |
-| configmap.cache | int | `30` |  |
-| configmap.custom | string | `""` |  |
-| configmap.log | string | `"denial\nerror\n"` |  |
-| controlPlane.nodeSelector."node-role.kubernetes.io/control-plane" | string | `"\"\""` |  |
-| coredns.additionalZones | list | `[]` |  |
-| coredns.cluster.cache.denial.capacity | int | `9984` |  |
-| coredns.cluster.cache.denial.ttl | int | `5` |  |
-| coredns.cluster.cache.serveStale.enabled | bool | `false` |  |
-| coredns.cluster.cache.success.capacity | int | `9984` |  |
-| coredns.cluster.cache.success.ttl | int | `30` |  |
-| coredns.cluster.kubernetes.pods | string | `"verified"` |  |
-| coredns.cluster.loadbalance | string | `"round_robin"` |  |
-| coredns.cluster.log[0] | string | `"denial"` |  |
-| coredns.cluster.log[1] | string | `"error"` |  |
-| coredns.custom | string | `""` |  |
-| coredns.public.autopath | string | `""` |  |
-| coredns.public.cache.denial.capacity | int | `9984` |  |
-| coredns.public.cache.denial.ttl | int | `5` |  |
-| coredns.public.cache.serveStale.enabled | bool | `false` |  |
-| coredns.public.cache.success.capacity | int | `9984` |  |
-| coredns.public.cache.success.ttl | int | `30` |  |
-| coredns.public.forward.to | list | `[]` |  |
-| coredns.public.loadbalance | string | `"round_robin"` |  |
-| coredns.public.log[0] | string | `"denial"` |  |
-| coredns.public.log[1] | string | `"error"` |  |
-| groupID | int | `33` |  |
-| hpa.behavior.scaleDown.stabilizationWindowSeconds | int | `1800` |  |
-| hpa.enabled | bool | `true` |  |
-| hpa.maxReplicas | int | `50` |  |
-| hpa.metrics | list | `[]` |  |
-| hpa.minReplicas | int | `2` |  |
-| hpa.targetCPUUtilizationPercentage | int | `80` |  |
-| hpa.targetMemoryUtilizationPercentage | int | `0` |  |
-| image.name | string | `"giantswarm/coredns"` |  |
-| image.registry | string | `"gsoci.azurecr.io"` |  |
-| image.tag | string | `"1.14.3"` |  |
-| loadbalancePolicy | string | `"round_robin"` |  |
-| mastersInstance.enabled | bool | `true` |  |
-| mastersInstance.nodeSelector."node-role.kubernetes.io/control-plane" | string | `"\"\""` |  |
-| name | string | `"coredns"` |  |
-| namespace | string | `"kube-system"` |  |
-| podDisruptionBudget.maxUnavailable | string | `"25%"` |  |
-| ports.dns.name | string | `"dns"` |  |
-| ports.dns.port | int | `53` |  |
-| ports.dns.targetPort | int | `1053` |  |
-| ports.metrics | object | `{}` |  |
-| resources.limits.memory | string | `"1Gi"` |  |
-| resources.requests.cpu | string | `"250m"` |  |
-| resources.requests.memory | string | `"512Mi"` |  |
-| securityContext | object | `{}` |  |
-| service | object | `{}` |  |
-| serviceType | string | `"managed"` |  |
-| updateStrategy.rollingUpdate.maxUnavailable | int | `1` |  |
-| updateStrategy.type | string | `"RollingUpdate"` |  |
-| userID | int | `33` |  |
+| adopter | object | `{"enabled":false,"image":"gsoci.azurecr.io/giantswarm/docker-kubectl:1.36.1"}` | Adopter job that takes ownership of pre-existing CoreDNS resources. |
+| adopter.enabled | bool | `false` | Enable the adopter job. |
+| adopter.image | string | `"gsoci.azurecr.io/giantswarm/docker-kubectl:1.36.1"` | Image used by the adopter job. |
+| cluster | object | `{"calico":{"CIDR":"192.168.0.0/16"},"kubernetes":{"API":{"clusterIPRange":"172.31.0.0/16"},"DNS":{"IP":"172.31.0.10"},"clusterDomain":"cluster.local"}}` | DEPRECATED: use coredns.cluster.* for Corefile config and service.clusterIP for the DNS service IP. |
+| cluster.calico | object | `{"CIDR":"192.168.0.0/16"}` | Calico configuration. |
+| cluster.calico.CIDR | string | `"192.168.0.0/16"` | Pod CIDR. |
+| cluster.kubernetes | object | `{"API":{"clusterIPRange":"172.31.0.0/16"},"DNS":{"IP":"172.31.0.10"},"clusterDomain":"cluster.local"}` | Kubernetes cluster configuration. |
+| cluster.kubernetes.API | object | `{"clusterIPRange":"172.31.0.0/16"}` | API server configuration. |
+| cluster.kubernetes.API.clusterIPRange | string | `"172.31.0.0/16"` | Service IP range. |
+| cluster.kubernetes.DNS | object | `{"IP":"172.31.0.10"}` | Cluster DNS configuration. |
+| cluster.kubernetes.DNS.IP | string | `"172.31.0.10"` | Cluster DNS service IP. |
+| cluster.kubernetes.clusterDomain | string | `"cluster.local"` | Cluster DNS domain. |
+| configmap | object | `{"cache":30,"custom":"","forward":null,"forwardOptions":null,"log":"denial\nerror\n"}` | DEPRECATED: use coredns.* instead. coredns.public.cache.success.ttl / coredns.cluster.cache.success.ttl replace configmap.cache; coredns.<zone>.log replaces configmap.log; coredns.public.forward.to replaces configmap.forward; coredns.public.forward.* replaces configmap.forwardOptions; coredns.public.autopath replaces configmap.autopath; coredns.custom replaces configmap.custom. |
+| configmap.cache | int | `30` | DEPRECATED: use coredns.<zone>.cache.success.ttl. Cache TTL seed (seconds). |
+| configmap.custom | string | `""` | DEPRECATED: use coredns.custom. Raw Corefile snippet. |
+| configmap.forward | string | `nil` | DEPRECATED: use coredns.public.forward.to. Forward directive (see https://coredns.io/plugins/forward/), e.g. ". 192.168.1.1 /etc/resolv.conf". |
+| configmap.forwardOptions | string | `nil` | DEPRECATED: use coredns.public.forward. Newline-separated forward plugin options. |
+| configmap.log | string | `"denial\nerror\n"` | DEPRECATED: use coredns.<zone>.log. Newline-separated log classes. |
+| controlPlane | object | `{"enabled":null,"nodeSelector":{"node-role.kubernetes.io/control-plane":"\"\""}}` | Control-plane CoreDNS instance configuration. |
+| controlPlane.enabled | string | `nil` | Whether to deploy the control-plane CoreDNS instance. Defaults to mastersInstance.enabled for backward compatibility. |
+| controlPlane.nodeSelector | object | `{"node-role.kubernetes.io/control-plane":"\"\""}` | Node selector for the control-plane CoreDNS instance. |
+| coredns | object | `{"additionalZones":[],"cluster":{"cache":{"denial":{"capacity":9984,"minTTL":null,"ttl":5},"disable":{"denial":null,"denialZones":[],"success":null,"successZones":[]},"keepttl":false,"prefetch":{"amount":null,"duration":null,"percentage":null},"serveStale":{"duration":null,"enabled":false,"refreshMode":null,"verifyTimeout":null},"servfail":{"duration":null},"success":{"capacity":9984,"minTTL":null,"ttl":30},"ttl":null,"zones":[]},"domains":null,"kubernetes":{"apiserverBurst":null,"apiserverMaxInflight":null,"apiserverQPS":null,"endpoint":null,"endpointPodNames":false,"fallthrough":false,"fallthroughZones":[],"ignoreEmptyService":false,"kubeconfig":{"context":null,"path":null},"labels":null,"multicluster":[],"namespaceLabels":null,"namespaces":[],"noendpoints":false,"pods":"verified","startupTimeout":null,"tls":{"ca":null,"cert":null,"key":null},"ttl":null},"loadbalance":"round_robin","log":["denial","error"],"podCIDR":null,"serviceCIDR":null},"custom":"","public":{"autopath":"","cache":{"denial":{"capacity":9984,"minTTL":null,"ttl":5},"disable":{"denial":null,"denialZones":[],"success":null,"successZones":[]},"keepttl":false,"prefetch":{"amount":null,"duration":null,"percentage":null},"serveStale":{"duration":null,"enabled":false,"refreshMode":null,"verifyTimeout":null},"servfail":{"duration":null},"success":{"capacity":9984,"minTTL":null,"ttl":30},"ttl":null,"zones":[]},"forward":{"dohMethod":null,"except":[],"expire":null,"failfastAllUnhealthyUpstreams":false,"failover":[],"forceTCP":false,"healthCheck":null,"maxConcurrent":null,"maxConnectAttempts":null,"maxFails":null,"maxIdleConns":null,"next":[],"nextOnNodata":false,"policy":null,"preferUDP":false,"resolver":[],"tls":{"ca":null,"cert":null,"enabled":false,"key":null},"tlsServername":null,"to":[]},"loadbalance":"round_robin","log":["denial","error"]}}` | CoreDNS Corefile configuration. Cache, log and loadbalance are configured per zone, so different zones can behave differently. A zone that omits cache falls back to the built-in defaults (success 9984 30 / denial 9984 5); a zone that omits log/loadbalance falls back to denial+error / round_robin. |
+| coredns.additionalZones | list | `[]` | Additional fully-templated local zones. Each entry is its own CoreDNS server block and renders whichever of forward/kubernetes it declares (or both, or neither). Per-entry keys: names (required), cidrs, cache, forward, kubernetes, log, loadbalance — same shapes as coredns.public/coredns.cluster. |
+| coredns.cluster | object | `{"cache":{"denial":{"capacity":9984,"minTTL":null,"ttl":5},"disable":{"denial":null,"denialZones":[],"success":null,"successZones":[]},"keepttl":false,"prefetch":{"amount":null,"duration":null,"percentage":null},"serveStale":{"duration":null,"enabled":false,"refreshMode":null,"verifyTimeout":null},"servfail":{"duration":null},"success":{"capacity":9984,"minTTL":null,"ttl":30},"ttl":null,"zones":[]},"domains":null,"kubernetes":{"apiserverBurst":null,"apiserverMaxInflight":null,"apiserverQPS":null,"endpoint":null,"endpointPodNames":false,"fallthrough":false,"fallthroughZones":[],"ignoreEmptyService":false,"kubeconfig":{"context":null,"path":null},"labels":null,"multicluster":[],"namespaceLabels":null,"namespaces":[],"noendpoints":false,"pods":"verified","startupTimeout":null,"tls":{"ca":null,"cert":null,"key":null},"ttl":null},"loadbalance":"round_robin","log":["denial","error"],"podCIDR":null,"serviceCIDR":null}` | The cluster.local zone — in-cluster DNS served by the kubernetes plugin. |
+| coredns.cluster.cache | object | `{"denial":{"capacity":9984,"minTTL":null,"ttl":5},"disable":{"denial":null,"denialZones":[],"success":null,"successZones":[]},"keepttl":false,"prefetch":{"amount":null,"duration":null,"percentage":null},"serveStale":{"duration":null,"enabled":false,"refreshMode":null,"verifyTimeout":null},"servfail":{"duration":null},"success":{"capacity":9984,"minTTL":null,"ttl":30},"ttl":null,"zones":[]}` | Cache plugin configuration for this zone (https://coredns.io/plugins/cache/). |
+| coredns.cluster.cache.denial | object | `{"capacity":9984,"minTTL":null,"ttl":5}` | Caching of negative (NXDOMAIN/NODATA) responses. |
+| coredns.cluster.cache.denial.capacity | int | `9984` | Maximum number of cached negative responses. |
+| coredns.cluster.cache.denial.minTTL | string | `nil` | Min TTL for negative responses (seconds). |
+| coredns.cluster.cache.denial.ttl | int | `5` | Max TTL for negative responses (seconds). |
+| coredns.cluster.cache.disable | object | `{"denial":null,"denialZones":[],"success":null,"successZones":[]}` | Selectively disable caching. |
+| coredns.cluster.cache.disable.denial | string | `nil` | Disable caching of negative responses. |
+| coredns.cluster.cache.disable.denialZones | list | `[]` | Limit the denial disable to these zones. |
+| coredns.cluster.cache.disable.success | string | `nil` | Disable caching of positive responses. |
+| coredns.cluster.cache.disable.successZones | list | `[]` | Limit the success disable to these zones. |
+| coredns.cluster.cache.keepttl | bool | `false` | Preserve original TTLs instead of counting them down. |
+| coredns.cluster.cache.prefetch | object | `{"amount":null,"duration":null,"percentage":null}` | Prefetch popular entries before they expire. |
+| coredns.cluster.cache.prefetch.amount | string | `nil` | Prefetch when at least this many requests are received (enables prefetch). |
+| coredns.cluster.cache.prefetch.duration | string | `nil` | Only prefetch if the item was requested within this duration. |
+| coredns.cluster.cache.prefetch.percentage | string | `nil` | Only prefetch if this percentage of the TTL remains (requires duration). |
+| coredns.cluster.cache.serveStale | object | `{"duration":null,"enabled":false,"refreshMode":null,"verifyTimeout":null}` | Serve stale answers while refreshing in the background. |
+| coredns.cluster.cache.serveStale.duration | string | `nil` | How long stale answers may be served. |
+| coredns.cluster.cache.serveStale.enabled | bool | `false` | Enable serving stale answers. |
+| coredns.cluster.cache.serveStale.refreshMode | string | `nil` | Refresh mode. |
+| coredns.cluster.cache.serveStale.verifyTimeout | string | `nil` | With refreshMode verify — max wait for upstream verify before serving stale. |
+| coredns.cluster.cache.servfail | object | `{"duration":null}` | SERVFAIL caching. |
+| coredns.cluster.cache.servfail.duration | string | `nil` | How long to cache SERVFAIL responses. |
+| coredns.cluster.cache.success | object | `{"capacity":9984,"minTTL":null,"ttl":30}` | Caching of positive (success) responses. |
+| coredns.cluster.cache.success.capacity | int | `9984` | Maximum number of cached positive responses. |
+| coredns.cluster.cache.success.minTTL | string | `nil` | Min TTL for positive responses (seconds). |
+| coredns.cluster.cache.success.ttl | int | `30` | Max TTL for positive responses (seconds). Defaults to configmap.cache for backward compatibility. |
+| coredns.cluster.cache.ttl | string | `nil` | Top-level TTL cap applied before the success/denial checks (seconds). |
+| coredns.cluster.cache.zones | list | `[]` | Cache ZONES — limit caching to these zones. Empty means the server-block zones. |
+| coredns.cluster.domains | string | `nil` | Zone names served by this block. Defaults to cluster.kubernetes.clusterDomain when unset. |
+| coredns.cluster.kubernetes | object | `{"apiserverBurst":null,"apiserverMaxInflight":null,"apiserverQPS":null,"endpoint":null,"endpointPodNames":false,"fallthrough":false,"fallthroughZones":[],"ignoreEmptyService":false,"kubeconfig":{"context":null,"path":null},"labels":null,"multicluster":[],"namespaceLabels":null,"namespaces":[],"noendpoints":false,"pods":"verified","startupTimeout":null,"tls":{"ca":null,"cert":null,"key":null},"ttl":null}` | Kubernetes plugin configuration (https://coredns.io/plugins/kubernetes/). Leave a key unset to keep the CoreDNS default. |
+| coredns.cluster.kubernetes.apiserverBurst | string | `nil` | apiserver_burst — max burst size for API server requests. |
+| coredns.cluster.kubernetes.apiserverMaxInflight | string | `nil` | apiserver_max_inflight — max concurrent in-flight API server requests. |
+| coredns.cluster.kubernetes.apiserverQPS | string | `nil` | apiserver_qps — max queries-per-second to the API server. |
+| coredns.cluster.kubernetes.endpoint | string | `nil` | endpoint URL — remote k8s API endpoint (omit for in-cluster). |
+| coredns.cluster.kubernetes.endpointPodNames | bool | `false` | endpoint_pod_names — use the pod name instead of the dashed IP. |
+| coredns.cluster.kubernetes.fallthrough | bool | `false` | fallthrough — pass unresolved queries to the next plugin (all zones). |
+| coredns.cluster.kubernetes.fallthroughZones | list | `[]` | fallthrough ZONES... — limit fallthrough to these zones. |
+| coredns.cluster.kubernetes.ignoreEmptyService | bool | `false` | ignore empty_service — NXDOMAIN for services without ready endpoints. |
+| coredns.cluster.kubernetes.kubeconfig | object | `{"context":null,"path":null}` | kubeconfig KUBECONFIG [CONTEXT] — authenticate via a kubeconfig file. |
+| coredns.cluster.kubernetes.kubeconfig.context | string | `nil` | Context within the kubeconfig file. |
+| coredns.cluster.kubernetes.kubeconfig.path | string | `nil` | Path to the kubeconfig file. |
+| coredns.cluster.kubernetes.labels | string | `nil` | labels EXPRESSION — expose only objects matching the selector. |
+| coredns.cluster.kubernetes.multicluster | list | `[]` | multicluster ZONES... — MCS-API multicluster zones. |
+| coredns.cluster.kubernetes.namespaceLabels | string | `nil` | namespace_labels EXPRESSION — expose only namespaces matching the selector. |
+| coredns.cluster.kubernetes.namespaces | list | `[]` | namespaces NAMESPACE... — expose only these namespaces. |
+| coredns.cluster.kubernetes.noendpoints | bool | `false` | noendpoints — disable endpoint record serving. |
+| coredns.cluster.kubernetes.pods | string | `"verified"` | pods — pod record mode. |
+| coredns.cluster.kubernetes.startupTimeout | string | `nil` | startup_timeout — wait for informer cache sync at startup. |
+| coredns.cluster.kubernetes.tls | object | `{"ca":null,"cert":null,"key":null}` | tls CERT KEY CACERT — for a remote k8s connection. |
+| coredns.cluster.kubernetes.tls.ca | string | `nil` | CA cert file path. |
+| coredns.cluster.kubernetes.tls.cert | string | `nil` | Client cert file path. |
+| coredns.cluster.kubernetes.tls.key | string | `nil` | Client key file path. |
+| coredns.cluster.kubernetes.ttl | string | `nil` | ttl SECONDS (0–3600). |
+| coredns.cluster.loadbalance | string | `"round_robin"` | Load balancing policy. Omit to fall back to round_robin. |
+| coredns.cluster.log | list | `["denial","error"]` | CoreDNS log classes for this zone. Omit to fall back to denial+error. |
+| coredns.cluster.podCIDR | string | `nil` | Pod CIDR for the reverse zone. Defaults to cluster.calico.CIDR when unset. |
+| coredns.cluster.serviceCIDR | string | `nil` | Service CIDR for the reverse zone. Defaults to cluster.kubernetes.API.clusterIPRange when unset. |
+| coredns.custom | string | `""` | Raw Corefile snippet appended verbatim at the end of the configuration. |
+| coredns.public | object | `{"autopath":"","cache":{"denial":{"capacity":9984,"minTTL":null,"ttl":5},"disable":{"denial":null,"denialZones":[],"success":null,"successZones":[]},"keepttl":false,"prefetch":{"amount":null,"duration":null,"percentage":null},"serveStale":{"duration":null,"enabled":false,"refreshMode":null,"verifyTimeout":null},"servfail":{"duration":null},"success":{"capacity":9984,"minTTL":null,"ttl":30},"ttl":null,"zones":[]},"forward":{"dohMethod":null,"except":[],"expire":null,"failfastAllUnhealthyUpstreams":false,"failover":[],"forceTCP":false,"healthCheck":null,"maxConcurrent":null,"maxConnectAttempts":null,"maxFails":null,"maxIdleConns":null,"next":[],"nextOnNodata":false,"policy":null,"preferUDP":false,"resolver":[],"tls":{"ca":null,"cert":null,"enabled":false,"key":null},"tlsServername":null,"to":[]},"loadbalance":"round_robin","log":["denial","error"]}` | The "." zone — external/public DNS served by the forward plugin. |
+| coredns.public.autopath | string | `""` | autopath plugin args, e.g. "@kubernetes". Empty disables autopath. |
+| coredns.public.cache | object | `{"denial":{"capacity":9984,"minTTL":null,"ttl":5},"disable":{"denial":null,"denialZones":[],"success":null,"successZones":[]},"keepttl":false,"prefetch":{"amount":null,"duration":null,"percentage":null},"serveStale":{"duration":null,"enabled":false,"refreshMode":null,"verifyTimeout":null},"servfail":{"duration":null},"success":{"capacity":9984,"minTTL":null,"ttl":30},"ttl":null,"zones":[]}` | Cache plugin configuration for this zone (https://coredns.io/plugins/cache/). |
+| coredns.public.cache.denial | object | `{"capacity":9984,"minTTL":null,"ttl":5}` | Caching of negative (NXDOMAIN/NODATA) responses. |
+| coredns.public.cache.denial.capacity | int | `9984` | Maximum number of cached negative responses. |
+| coredns.public.cache.denial.minTTL | string | `nil` | Min TTL for negative responses (seconds). |
+| coredns.public.cache.denial.ttl | int | `5` | Max TTL for negative responses (seconds). |
+| coredns.public.cache.disable | object | `{"denial":null,"denialZones":[],"success":null,"successZones":[]}` | Selectively disable caching. |
+| coredns.public.cache.disable.denial | string | `nil` | Disable caching of negative responses. |
+| coredns.public.cache.disable.denialZones | list | `[]` | Limit the denial disable to these zones. |
+| coredns.public.cache.disable.success | string | `nil` | Disable caching of positive responses. |
+| coredns.public.cache.disable.successZones | list | `[]` | Limit the success disable to these zones. |
+| coredns.public.cache.keepttl | bool | `false` | Preserve original TTLs instead of counting them down. |
+| coredns.public.cache.prefetch | object | `{"amount":null,"duration":null,"percentage":null}` | Prefetch popular entries before they expire. |
+| coredns.public.cache.prefetch.amount | string | `nil` | Prefetch when at least this many requests are received (enables prefetch). |
+| coredns.public.cache.prefetch.duration | string | `nil` | Only prefetch if the item was requested within this duration. |
+| coredns.public.cache.prefetch.percentage | string | `nil` | Only prefetch if this percentage of the TTL remains (requires duration). |
+| coredns.public.cache.serveStale | object | `{"duration":null,"enabled":false,"refreshMode":null,"verifyTimeout":null}` | Serve stale answers while refreshing in the background. |
+| coredns.public.cache.serveStale.duration | string | `nil` | How long stale answers may be served. |
+| coredns.public.cache.serveStale.enabled | bool | `false` | Enable serving stale answers. |
+| coredns.public.cache.serveStale.refreshMode | string | `nil` | Refresh mode. |
+| coredns.public.cache.serveStale.verifyTimeout | string | `nil` | With refreshMode verify — max wait for upstream verify before serving stale. |
+| coredns.public.cache.servfail | object | `{"duration":null}` | SERVFAIL caching. |
+| coredns.public.cache.servfail.duration | string | `nil` | How long to cache SERVFAIL responses. |
+| coredns.public.cache.success | object | `{"capacity":9984,"minTTL":null,"ttl":30}` | Caching of positive (success) responses. |
+| coredns.public.cache.success.capacity | int | `9984` | Maximum number of cached positive responses. |
+| coredns.public.cache.success.minTTL | string | `nil` | Min TTL for positive responses (seconds). |
+| coredns.public.cache.success.ttl | int | `30` | Max TTL for positive responses (seconds). Defaults to configmap.cache for backward compatibility. |
+| coredns.public.cache.ttl | string | `nil` | Top-level TTL cap applied before the success/denial checks (seconds). |
+| coredns.public.cache.zones | list | `[]` | Cache ZONES — limit caching to these zones. Empty means the server-block zones. |
+| coredns.public.forward | object | `{"dohMethod":null,"except":[],"expire":null,"failfastAllUnhealthyUpstreams":false,"failover":[],"forceTCP":false,"healthCheck":null,"maxConcurrent":null,"maxConnectAttempts":null,"maxFails":null,"maxIdleConns":null,"next":[],"nextOnNodata":false,"policy":null,"preferUDP":false,"resolver":[],"tls":{"ca":null,"cert":null,"enabled":false,"key":null},"tlsServername":null,"to":[]}` | Forward plugin configuration (https://coredns.io/plugins/forward/). The FROM is always ".". Only a representative subset of parameters is wired up today; leave a key unset to keep the CoreDNS default. |
+| coredns.public.forward.dohMethod | string | `nil` | doh_method — HTTP method for DoH requests. |
+| coredns.public.forward.except | list | `[]` | except NAMES — domains to pass through unforwarded. |
+| coredns.public.forward.expire | string | `nil` | expire — close idle upstream connections after this duration. |
+| coredns.public.forward.failfastAllUnhealthyUpstreams | bool | `false` | failfast_all_unhealthy_upstreams — SERVFAIL when all upstreams are down. |
+| coredns.public.forward.failover | list | `[]` | failover RCODE... — retry the next upstream on these rcodes (e.g. [SERVFAIL, REFUSED]). |
+| coredns.public.forward.forceTCP | bool | `false` | force_tcp — always use TCP to the upstream. |
+| coredns.public.forward.healthCheck | string | `nil` | health_check DURATION [no_rec] [domain FQDN]. |
+| coredns.public.forward.maxConcurrent | string | `nil` | max_concurrent — maximum number of concurrent queries to forward. |
+| coredns.public.forward.maxConnectAttempts | string | `nil` | max_connect_attempts — cap on connect attempts per request (0 = no cap). |
+| coredns.public.forward.maxFails | string | `nil` | max_fails — consecutive failed health checks before marking an upstream down. |
+| coredns.public.forward.maxIdleConns | string | `nil` | max_idle_conns — idle connections cached per upstream (0 = unlimited). |
+| coredns.public.forward.next | list | `[]` | next RCODE... — run the next forward plugin on these rcodes (e.g. [NXDOMAIN]). |
+| coredns.public.forward.nextOnNodata | bool | `false` | next_on_nodata — run the next forward plugin on empty NOERROR answers. |
+| coredns.public.forward.policy | string | `nil` | policy — upstream selection policy. |
+| coredns.public.forward.preferUDP | bool | `false` | prefer_udp — try UDP first even for queries received over TCP. |
+| coredns.public.forward.resolver | list | `[]` | resolver IP[:PORT]... — resolvers for hostname-based "to" endpoints. |
+| coredns.public.forward.tls | object | `{"ca":null,"cert":null,"enabled":false,"key":null}` | tls CERT KEY CA — set cert+key, ca, all three, or enabled for bare tls. |
+| coredns.public.forward.tls.ca | string | `nil` | CA cert file path. |
+| coredns.public.forward.tls.cert | string | `nil` | Client cert file path. |
+| coredns.public.forward.tls.enabled | bool | `false` | Emit bare "tls" (system CAs, no client auth). |
+| coredns.public.forward.tls.key | string | `nil` | Client key file path. |
+| coredns.public.forward.tlsServername | string | `nil` | tls_servername NAME — expected server cert name (e.g. dns.quad9.net). |
+| coredns.public.forward.to | list | `[]` | Upstream DNS servers (the forward TO targets). Empty means use /etc/resolv.conf. |
+| coredns.public.loadbalance | string | `"round_robin"` | Load balancing policy. Omit to fall back to round_robin. |
+| coredns.public.log | list | `["denial","error"]` | CoreDNS log classes for this zone. Omit to fall back to denial+error. |
+| groupID | int | `33` | DEPRECATED: use securityContext.runAsGroup. GID the CoreDNS process runs as. |
+| hpa | object | `{"behavior":{"scaleDown":{"stabilizationWindowSeconds":1800}},"enabled":true,"maxReplicas":50,"metrics":[],"minReplicas":2,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":0}` | Horizontal Pod Autoscaler configuration. |
+| hpa.behavior | object | `{"scaleDown":{"stabilizationWindowSeconds":1800}}` | Scaling behavior. The stabilization window restricts replica-count flapping when the scaling metrics keep fluctuating. |
+| hpa.behavior.scaleDown | object | `{"stabilizationWindowSeconds":1800}` | Scale-down behavior. |
+| hpa.behavior.scaleDown.stabilizationWindowSeconds | int | `1800` | Seconds to consider while scaling down to prevent flapping. |
+| hpa.enabled | bool | `true` | Enable the HorizontalPodAutoscaler. |
+| hpa.maxReplicas | int | `50` | Maximum number of replicas. |
+| hpa.metrics | list | `[]` | Additional custom metrics for the HPA (autoscaling/v2 metric objects). |
+| hpa.minReplicas | int | `2` | Minimum number of replicas. |
+| hpa.targetCPUUtilizationPercentage | int | `80` | Target average CPU utilization percentage. |
+| hpa.targetMemoryUtilizationPercentage | int | `0` | Target average memory utilization percentage. Set to 0 to disable the memory metric. |
+| image | object | `{"name":"giantswarm/coredns","registry":"gsoci.azurecr.io","tag":"1.14.4"}` | Container image for CoreDNS. |
+| image.name | string | `"giantswarm/coredns"` | Image repository. |
+| image.registry | string | `"gsoci.azurecr.io"` | Image registry. |
+| image.tag | string | `"1.14.4"` | Image tag. |
+| loadbalancePolicy | string | `"round_robin"` | DEPRECATED: use coredns.<zone>.loadbalance (per-zone). Load balancing policy. |
+| mastersInstance | object | `{"enabled":true,"nodeSelector":{"node-role.kubernetes.io/control-plane":"\"\""}}` | DEPRECATED: use controlPlane. mastersInstance.enabled stays backward compatible — controlPlane.enabled takes precedence only when explicitly set. |
+| mastersInstance.enabled | bool | `true` | Whether to deploy the control-plane CoreDNS instance. |
+| mastersInstance.nodeSelector | object | `{"node-role.kubernetes.io/control-plane":"\"\""}` | Node selector for the control-plane CoreDNS instance. |
+| name | string | `"coredns"` | Name used for the CoreDNS workload and its resources. |
+| namespace | string | `"kube-system"` | Namespace the CoreDNS resources are deployed into. |
+| podDisruptionBudget | object | `{"maxUnavailable":"25%"}` | Pod disruption budget for the CoreDNS workloads. |
+| podDisruptionBudget.maxUnavailable | string | `"25%"` | Maximum number of pods that can be unavailable to voluntary disruptions. |
+| ports | object | `{"dns":{"name":"dns","port":53,"targetPort":1053},"metrics":{"port":null}}` | Ports exposed by CoreDNS. |
+| ports.dns | object | `{"name":"dns","port":53,"targetPort":1053}` | DNS port configuration. |
+| ports.dns.name | string | `"dns"` | Port name. |
+| ports.dns.port | int | `53` | Service port exposed for DNS. |
+| ports.dns.targetPort | int | `1053` | Container port CoreDNS listens on. |
+| ports.metrics | object | `{"port":null}` | Prometheus metrics port configuration. |
+| ports.metrics.port | string | `nil` | Port for the Prometheus metrics endpoint. Defaults to 9153 when unset. |
+| resources | object | `{"limits":{"memory":"1Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Resource requests and limits for the CoreDNS containers. |
+| resources.limits | object | `{"memory":"1Gi"}` | Resource limits. |
+| resources.limits.memory | string | `"1Gi"` | Memory limit. |
+| resources.requests | object | `{"cpu":"250m","memory":"512Mi"}` | Resource requests. |
+| resources.requests.cpu | string | `"250m"` | CPU request. |
+| resources.requests.memory | string | `"512Mi"` | Memory request. |
+| securityContext | object | `{"runAsGroup":null,"runAsUser":null}` | Pod-level security context for the CoreDNS containers. |
+| securityContext.runAsGroup | string | `nil` | GID the CoreDNS process runs as. Defaults to groupID when unset. |
+| securityContext.runAsUser | string | `nil` | UID the CoreDNS process runs as. Defaults to userID when unset. |
+| service | object | `{"clusterIP":null}` | Configuration for the CoreDNS Service. |
+| service.clusterIP | string | `nil` | Cluster IP of the DNS Service. Defaults to cluster.kubernetes.DNS.IP when unset. |
+| serviceType | string | `"managed"` | Giant Swarm service type label applied to the resources. |
+| updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | Update strategy for the CoreDNS workloads. |
+| updateStrategy.rollingUpdate | object | `{"maxUnavailable":1}` | Rolling update parameters. |
+| updateStrategy.rollingUpdate.maxUnavailable | int | `1` | Maximum number of pods that can be unavailable during the update. |
+| updateStrategy.type | string | `"RollingUpdate"` | Update strategy type. |
+| userID | int | `33` | DEPRECATED: use securityContext.runAsUser. UID the CoreDNS process runs as. |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/helm/coredns-app/values.schema.json
+++ b/helm/coredns-app/values.schema.json
@@ -1,459 +1,1025 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
-    "definitions": {
-        "cache": {
-            "description": "CoreDNS cache plugin configuration for a zone.",
-            "type": "object",
-            "properties": {
-                "ttl": {
-                    "description": "Top-level TTL cap applied to all cached entries (seconds).",
-                    "type": "integer"
-                },
-                "zones": {
-                    "description": "Zones the cache applies to (cache 'ZONES'). If empty, the zones from the server block are used.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "success": {
-                    "description": "Configuration for caching positive (success) responses.",
-                    "type": "object",
-                    "properties": {
-                        "capacity": {
-                            "description": "Maximum number of positive responses to cache.",
-                            "type": "integer"
-                        },
-                        "ttl": {
-                            "description": "Max TTL for positive responses (seconds). Defaults to configmap.cache for backward compatibility.",
-                            "type": "integer"
-                        },
-                        "minTTL": {
-                            "description": "Min TTL for positive responses (seconds).",
-                            "type": "integer"
-                        }
-                    }
-                },
-                "denial": {
-                    "description": "Configuration for caching negative (NXDOMAIN/NODATA) responses.",
-                    "type": "object",
-                    "properties": {
-                        "capacity": {
-                            "description": "Maximum number of negative responses to cache.",
-                            "type": "integer"
-                        },
-                        "ttl": {
-                            "description": "Max TTL for NXDOMAIN/NODATA responses (seconds).",
-                            "type": "integer"
-                        },
-                        "minTTL": {
-                            "description": "Min TTL for denial responses (seconds).",
-                            "type": "integer"
-                        }
-                    }
-                },
-                "prefetch": {
-                    "description": "Prefetch popular cache entries before they expire.",
-                    "type": "object",
-                    "properties": {
-                        "amount": {
-                            "description": "Prefetch entries accessed at least this many times. Required to enable prefetch.",
-                            "type": "integer"
-                        },
-                        "duration": {
-                            "description": "Only prefetch if the entry was requested within this duration (e.g. 1m).",
-                            "type": "string"
-                        },
-                        "percentage": {
-                            "description": "Only prefetch if this percentage of TTL remains. Requires duration.",
-                            "type": "integer"
-                        }
-                    }
-                },
-                "serveStale": {
-                    "description": "Serve stale (expired) cache entries while fetching a fresh answer.",
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "description": "Enable serving stale cache entries while refreshing.",
-                            "type": "boolean"
-                        },
-                        "duration": {
-                            "description": "How long stale answers may be served (e.g. 1h).",
-                            "type": "string"
-                        },
-                        "refreshMode": {
-                            "description": "Refresh mode for stale entries. 'immediate' serves the stale entry before checking the source; 'verify' confirms the entry is still unavailable first.",
-                            "type": "string",
-                            "enum": ["immediate", "verify"]
-                        },
-                        "verifyTimeout": {
-                            "description": "Only valid with refreshMode 'verify'. Bounds how long the cache waits for the upstream verify before falling back to the stale entry (e.g. 100ms). Default 0 waits for the upstream's own timeout.",
-                            "type": "string"
-                        }
-                    }
-                },
-                "servfail": {
-                    "description": "Configuration for caching SERVFAIL responses.",
-                    "type": "object",
-                    "properties": {
-                        "duration": {
-                            "description": "How long to cache SERVFAIL responses (e.g. 5s). Set to 0 to disable.",
-                            "type": "string"
-                        }
-                    }
-                },
-                "disable": {
-                    "description": "Disable caching for specific response types.",
-                    "type": "object",
-                    "properties": {
-                        "success": {
-                            "description": "Disable caching of positive responses.",
-                            "type": "boolean"
-                        },
-                        "successZones": {
-                            "description": "Limit the success-cache disable to these zones (disable success 'ZONES'). Omit to disable for all zones.",
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "denial": {
-                            "description": "Disable caching of NXDOMAIN/NODATA responses.",
-                            "type": "boolean"
-                        },
-                        "denialZones": {
-                            "description": "Limit the denial-cache disable to these zones (disable denial 'ZONES'). Omit to disable for all zones.",
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "keepttl": {
-                    "description": "Preserve original TTLs in cached responses instead of counting down.",
-                    "type": "boolean"
-                }
-            }
-        },
-        "forward": {
-            "description": "Structured forward directive, mirroring the CoreDNS forward block. 'to' holds the upstream targets (FROM is always '.') and the remaining keys are forward plugin parameters. Only a representative subset is exposed; extend by adding keys here and in the coredns.forwardBlock helper.",
-            "type": "object",
-            "properties": {
-                "to": {
-                    "description": "List of upstream DNS server addresses (the forward 'TO...' targets). Empty list falls back to /etc/resolv.conf.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "policy": {
-                    "description": "Upstream selection policy (forward 'policy').",
-                    "type": "string",
-                    "enum": ["random", "round_robin", "sequential"]
-                },
-                "forceTCP": {
-                    "description": "Always use TCP to the upstream (forward 'force_tcp').",
-                    "type": "boolean"
-                },
-                "preferUDP": {
-                    "description": "Try UDP first even for queries received over TCP (forward 'prefer_udp').",
-                    "type": "boolean"
-                },
-                "maxFails": {
-                    "description": "Consecutive failed health checks before an upstream is considered down (forward 'max_fails').",
-                    "type": "integer"
-                },
-                "maxConnectAttempts": {
-                    "description": "Cap on total upstream connect attempts per request (forward 'max_connect_attempts'). 0 means no cap.",
-                    "type": "integer"
-                },
-                "maxIdleConns": {
-                    "description": "Maximum idle connections cached per upstream for reuse (forward 'max_idle_conns'). 0 means unlimited.",
-                    "type": "integer"
-                },
-                "healthCheck": {
-                    "description": "Upstream health-check configuration (forward 'health_check'), e.g. '0.2s', '0.2s no_rec', or '5s domain example.org'.",
-                    "type": "string"
-                },
-                "dohMethod": {
-                    "description": "HTTP method for DoH requests (forward 'doh_method').",
-                    "type": "string",
-                    "enum": ["GET", "POST"]
-                },
-                "tls": {
-                    "description": "TLS configuration for the upstream connection (forward 'tls'). Provide cert+key (client auth), ca (custom server verification), all three, or set enabled for a bare 'tls' using system CAs.",
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "description": "Emit a bare 'tls' directive (system CAs, no client auth) when no cert/key/ca are set.",
-                            "type": "boolean"
-                        },
-                        "cert": {
-                            "description": "Client certificate file path.",
-                            "type": "string"
-                        },
-                        "key": {
-                            "description": "Client key file path.",
-                            "type": "string"
-                        },
-                        "ca": {
-                            "description": "CA certificate file path used to verify the server certificate.",
-                            "type": "string"
-                        }
-                    }
-                },
-                "tlsServername": {
-                    "description": "Server name expected in the upstream TLS certificate (forward 'tls_servername'), e.g. 'dns.quad9.net'. Strongly recommended when forwarding over TLS.",
-                    "type": "string"
-                },
-                "expire": {
-                    "description": "Close idle upstream connections after this duration (forward 'expire'), e.g. '10s'.",
-                    "type": "string"
-                },
-                "maxConcurrent": {
-                    "description": "Maximum number of concurrent queries to forward (forward 'max_concurrent').",
-                    "type": "integer"
-                },
-                "next": {
-                    "description": "Response codes that cause the next forward plugin to be executed (forward 'next'), e.g. ['NXDOMAIN'].",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "nextOnNodata": {
-                    "description": "Execute the next forward plugin when the upstream returns NOERROR with an empty answer (forward 'next_on_nodata').",
-                    "type": "boolean"
-                },
-                "failfastAllUnhealthyUpstreams": {
-                    "description": "Immediately return SERVFAIL when all upstreams are unhealthy instead of spraying to a random upstream (forward 'failfast_all_unhealthy_upstreams').",
-                    "type": "boolean"
-                },
-                "failover": {
-                    "description": "Response codes that trigger a retry on the next upstream (forward 'failover'), e.g. ['SERVFAIL', 'REFUSED']. NOERROR is not allowed.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "resolver": {
-                    "description": "DNS resolver addresses used to resolve hostname-based 'to' endpoints at startup (forward 'resolver'), each a bare IP or IP:PORT.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "except": {
-                    "description": "Domain names to pass through unforwarded (forward 'except').",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "kubernetes": {
-            "description": "Structured kubernetes plugin parameters, mirroring the CoreDNS kubernetes block. Only a representative subset is exposed; extend by adding keys here and in the coredns.kubernetesBlock helper.",
-            "type": "object",
-            "properties": {
-                "endpoint": {
-                    "description": "URL of a remote k8s API endpoint (kubernetes 'endpoint'). Omit to connect in-cluster. Ignored when kubeconfig is set.",
-                    "type": "string"
-                },
-                "tls": {
-                    "description": "TLS cert, key and CA cert file paths for a remote k8s connection (kubernetes 'tls'). Ignored when connecting in-cluster.",
-                    "type": "object",
-                    "properties": {
-                        "cert": {
-                            "description": "Client certificate file path.",
-                            "type": "string"
-                        },
-                        "key": {
-                            "description": "Client key file path.",
-                            "type": "string"
-                        },
-                        "ca": {
-                            "description": "CA certificate file path.",
-                            "type": "string"
-                        }
-                    }
-                },
-                "kubeconfig": {
-                    "description": "Authenticate to a remote k8s cluster using a kubeconfig file (kubernetes 'kubeconfig').",
-                    "type": "object",
-                    "properties": {
-                        "path": {
-                            "description": "Path to the kubeconfig file.",
-                            "type": "string"
-                        },
-                        "context": {
-                            "description": "Optional kubeconfig context. Defaults to the current context.",
-                            "type": "string"
-                        }
-                    }
-                },
-                "apiserverQPS": {
-                    "description": "Maximum queries-per-second rate limit for API server requests (kubernetes 'apiserver_qps').",
-                    "type": "integer"
-                },
-                "apiserverBurst": {
-                    "description": "Maximum burst size for API server requests (kubernetes 'apiserver_burst').",
-                    "type": "integer"
-                },
-                "apiserverMaxInflight": {
-                    "description": "Maximum number of concurrent in-flight API server requests (kubernetes 'apiserver_max_inflight').",
-                    "type": "integer"
-                },
-                "pods": {
-                    "description": "Pod A record handling mode (kubernetes 'pods').",
-                    "type": "string",
-                    "enum": ["disabled", "insecure", "verified"]
-                },
-                "ttl": {
-                    "description": "Custom response TTL in seconds, range 0–3600 (kubernetes 'ttl').",
-                    "type": "integer"
-                },
-                "endpointPodNames": {
-                    "description": "Use the pod name instead of the dashed IP in endpoint records (kubernetes 'endpoint_pod_names').",
-                    "type": "boolean"
-                },
-                "noendpoints": {
-                    "description": "Disable serving endpoint records (kubernetes 'noendpoints').",
-                    "type": "boolean"
-                },
-                "namespaces": {
-                    "description": "Expose only the listed namespaces (kubernetes 'namespaces').",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "namespaceLabels": {
-                    "description": "Expose only namespaces matching this label selector expression (kubernetes 'namespace_labels').",
-                    "type": "string"
-                },
-                "labels": {
-                    "description": "Expose only objects matching this label selector expression (kubernetes 'labels').",
-                    "type": "string"
-                },
-                "ignoreEmptyService": {
-                    "description": "Return NXDOMAIN for services without ready endpoints (kubernetes 'ignore empty_service').",
-                    "type": "boolean"
-                },
-                "fallthrough": {
-                    "description": "Pass unresolved queries to the next plugin for all authoritative zones (kubernetes 'fallthrough'). Ignored when fallthroughZones is set.",
-                    "type": "boolean"
-                },
-                "fallthroughZones": {
-                    "description": "Limit fallthrough to these zones (kubernetes 'fallthrough ZONES'), e.g. ['in-addr.arpa', 'ip6.arpa'].",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "multicluster": {
-                    "description": "Multicluster zones served via the MCS-API (kubernetes 'multicluster'). The plugin must be authoritative for these zones.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "startupTimeout": {
-                    "description": "Time to wait for the informer cache to sync at startup (kubernetes 'startup_timeout'), e.g. '5s'.",
-                    "type": "string"
-                }
-            }
-        },
-        "log": {
-            "description": "List of CoreDNS log classes to emit for a zone. Omit to fall back to denial+error.",
-            "type": "array",
-            "items": {
-                "type": "string",
-                "enum": ["all", "success", "denial", "error", "stdout", "stderr"]
-            }
-        },
-        "loadbalance": {
-            "description": "Load balancing policy applied to a zone's DNS responses with multiple A/AAAA records. Omit to fall back to round_robin.",
-            "type": "string",
-            "enum": ["round_robin", "random"]
-        }
-    },
     "properties": {
-        "name": {
-            "description": "Name used for all chart resources.",
-            "type": "string"
-        },
-        "namespace": {
-            "description": "Namespace to deploy all chart resources into.",
-            "type": "string"
-        },
-        "serviceType": {
-            "description": "Giant Swarm service type label value.",
-            "type": "string"
-        },
-        "securityContext": {
-            "description": "Pod-level security context for CoreDNS containers.",
+        "adopter": {
+            "description": "Adopter job that takes ownership of pre-existing CoreDNS resources.",
             "type": "object",
             "properties": {
-                "runAsUser": {
-                    "description": "UID to run the CoreDNS container as.",
-                    "type": "integer"
+                "enabled": {
+                    "description": "Enable the adopter job.",
+                    "type": "boolean"
                 },
-                "runAsGroup": {
-                    "description": "GID to run the CoreDNS container as.",
-                    "type": "integer"
+                "image": {
+                    "description": "Image used by the adopter job.",
+                    "type": "string"
                 }
             }
         },
-        "service": {
-            "description": "Settings for the CoreDNS ClusterIP Service.",
+        "cluster": {
+            "description": "DEPRECATED: use coredns.cluster.* for Corefile config and service.clusterIP for the DNS service IP.",
             "type": "object",
             "properties": {
-                "clusterIP": {
-                    "description": "Fixed ClusterIP assigned to the CoreDNS service. Must be within the cluster service CIDR.",
+                "calico": {
+                    "description": "Calico configuration.",
+                    "type": "object",
+                    "properties": {
+                        "CIDR": {
+                            "description": "Pod CIDR.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "kubernetes": {
+                    "description": "Kubernetes cluster configuration.",
+                    "type": "object",
+                    "properties": {
+                        "API": {
+                            "description": "API server configuration.",
+                            "type": "object",
+                            "properties": {
+                                "clusterIPRange": {
+                                    "description": "Service IP range.",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "DNS": {
+                            "description": "Cluster DNS configuration.",
+                            "type": "object",
+                            "properties": {
+                                "IP": {
+                                    "description": "Cluster DNS service IP.",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "clusterDomain": {
+                            "description": "Cluster DNS domain.",
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "configmap": {
+            "description": "DEPRECATED: use coredns.* instead. coredns.public.cache.success.ttl / coredns.cluster.cache.success.ttl replace configmap.cache; coredns.\u003czone\u003e.log replaces configmap.log; coredns.public.forward.to replaces configmap.forward; coredns.public.forward.* replaces configmap.forwardOptions; coredns.public.autopath replaces configmap.autopath; coredns.custom replaces configmap.custom.",
+            "type": "object",
+            "properties": {
+                "cache": {
+                    "description": "DEPRECATED: use coredns.\u003czone\u003e.cache.success.ttl. Cache TTL seed (seconds).",
+                    "type": "integer"
+                },
+                "custom": {
+                    "description": "DEPRECATED: use coredns.custom. Raw Corefile snippet.",
                     "type": "string"
+                },
+                "forward": {
+                    "description": "DEPRECATED: use coredns.public.forward.to. Forward directive (see https://coredns.io/plugins/forward/), e.g. \". 192.168.1.1 /etc/resolv.conf\".",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "forwardOptions": {
+                    "description": "DEPRECATED: use coredns.public.forward. Newline-separated forward plugin options.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "log": {
+                    "description": "DEPRECATED: use coredns.\u003czone\u003e.log. Newline-separated log classes.",
+                    "type": "string"
+                }
+            }
+        },
+        "controlPlane": {
+            "description": "Control-plane CoreDNS instance configuration.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Whether to deploy the control-plane CoreDNS instance. Defaults to mastersInstance.enabled for backward compatibility.",
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
+                },
+                "nodeSelector": {
+                    "description": "Node selector for the control-plane CoreDNS instance.",
+                    "type": "object",
+                    "properties": {
+                        "node-role.kubernetes.io/control-plane": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "coredns": {
+            "description": "CoreDNS Corefile configuration. Cache, log and loadbalance are configured per zone, so different zones can behave differently. A zone that omits cache falls back to the built-in defaults (success 9984 30 / denial 9984 5); a zone that omits log/loadbalance falls back to denial+error / round_robin.",
+            "type": "object",
+            "properties": {
+                "additionalZones": {
+                    "description": "Additional fully-templated local zones. Each entry is its own CoreDNS server block and renders whichever of forward/kubernetes it declares (or both, or neither). Per-entry keys: names (required), cidrs, cache, forward, kubernetes, log, loadbalance — same shapes as coredns.public/coredns.cluster.",
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "cluster": {
+                    "description": "The cluster.local zone — in-cluster DNS served by the kubernetes plugin.",
+                    "type": "object",
+                    "properties": {
+                        "cache": {
+                            "description": "Cache plugin configuration for this zone (https://coredns.io/plugins/cache/).",
+                            "type": "object",
+                            "properties": {
+                                "denial": {
+                                    "description": "Caching of negative (NXDOMAIN/NODATA) responses.",
+                                    "type": "object",
+                                    "properties": {
+                                        "capacity": {
+                                            "description": "Maximum number of cached negative responses.",
+                                            "type": "integer"
+                                        },
+                                        "minTTL": {
+                                            "description": "Min TTL for negative responses (seconds).",
+                                            "type": [
+                                                "null",
+                                                "integer"
+                                            ]
+                                        },
+                                        "ttl": {
+                                            "description": "Max TTL for negative responses (seconds).",
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "disable": {
+                                    "description": "Selectively disable caching.",
+                                    "type": "object",
+                                    "properties": {
+                                        "denial": {
+                                            "description": "Disable caching of negative responses.",
+                                            "type": [
+                                                "null",
+                                                "boolean"
+                                            ]
+                                        },
+                                        "denialZones": {
+                                            "description": "Limit the denial disable to these zones.",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "success": {
+                                            "description": "Disable caching of positive responses.",
+                                            "type": [
+                                                "null",
+                                                "boolean"
+                                            ]
+                                        },
+                                        "successZones": {
+                                            "description": "Limit the success disable to these zones.",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "keepttl": {
+                                    "description": "Preserve original TTLs instead of counting them down.",
+                                    "type": "boolean"
+                                },
+                                "prefetch": {
+                                    "description": "Prefetch popular entries before they expire.",
+                                    "type": "object",
+                                    "properties": {
+                                        "amount": {
+                                            "description": "Prefetch when at least this many requests are received (enables prefetch).",
+                                            "type": [
+                                                "null",
+                                                "integer"
+                                            ]
+                                        },
+                                        "duration": {
+                                            "description": "Only prefetch if the item was requested within this duration.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "percentage": {
+                                            "description": "Only prefetch if this percentage of the TTL remains (requires duration).",
+                                            "type": [
+                                                "null",
+                                                "integer"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "serveStale": {
+                                    "description": "Serve stale answers while refreshing in the background.",
+                                    "type": "object",
+                                    "properties": {
+                                        "duration": {
+                                            "description": "How long stale answers may be served.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "enabled": {
+                                            "description": "Enable serving stale answers.",
+                                            "type": "boolean"
+                                        },
+                                        "refreshMode": {
+                                            "description": "Refresh mode.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ],
+                                            "enum": [
+                                                "immediate",
+                                                "verify",
+                                                null
+                                            ]
+                                        },
+                                        "verifyTimeout": {
+                                            "description": "With refreshMode verify — max wait for upstream verify before serving stale.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "servfail": {
+                                    "description": "SERVFAIL caching.",
+                                    "type": "object",
+                                    "properties": {
+                                        "duration": {
+                                            "description": "How long to cache SERVFAIL responses.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "success": {
+                                    "description": "Caching of positive (success) responses.",
+                                    "type": "object",
+                                    "properties": {
+                                        "capacity": {
+                                            "description": "Maximum number of cached positive responses.",
+                                            "type": "integer"
+                                        },
+                                        "minTTL": {
+                                            "description": "Min TTL for positive responses (seconds).",
+                                            "type": [
+                                                "null",
+                                                "integer"
+                                            ]
+                                        },
+                                        "ttl": {
+                                            "description": "Max TTL for positive responses (seconds). Defaults to configmap.cache for backward compatibility.",
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "ttl": {
+                                    "description": "Top-level TTL cap applied before the success/denial checks (seconds).",
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                },
+                                "zones": {
+                                    "description": "Cache ZONES — limit caching to these zones. Empty means the server-block zones.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "domains": {
+                            "description": "Zone names served by this block. Defaults to cluster.kubernetes.clusterDomain when unset.",
+                            "type": [
+                                "null",
+                                "array"
+                            ]
+                        },
+                        "kubernetes": {
+                            "description": "Kubernetes plugin configuration (https://coredns.io/plugins/kubernetes/). Leave a key unset to keep the CoreDNS default.",
+                            "type": "object",
+                            "properties": {
+                                "apiserverBurst": {
+                                    "description": "apiserver_burst — max burst size for API server requests.",
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                },
+                                "apiserverMaxInflight": {
+                                    "description": "apiserver_max_inflight — max concurrent in-flight API server requests.",
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                },
+                                "apiserverQPS": {
+                                    "description": "apiserver_qps — max queries-per-second to the API server.",
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                },
+                                "endpoint": {
+                                    "description": "endpoint URL — remote k8s API endpoint (omit for in-cluster).",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "endpointPodNames": {
+                                    "description": "endpoint_pod_names — use the pod name instead of the dashed IP.",
+                                    "type": "boolean"
+                                },
+                                "fallthrough": {
+                                    "description": "fallthrough — pass unresolved queries to the next plugin (all zones).",
+                                    "type": "boolean"
+                                },
+                                "fallthroughZones": {
+                                    "description": "fallthrough ZONES... — limit fallthrough to these zones.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "ignoreEmptyService": {
+                                    "description": "ignore empty_service — NXDOMAIN for services without ready endpoints.",
+                                    "type": "boolean"
+                                },
+                                "kubeconfig": {
+                                    "description": "kubeconfig KUBECONFIG [CONTEXT] — authenticate via a kubeconfig file.",
+                                    "type": "object",
+                                    "properties": {
+                                        "context": {
+                                            "description": "Context within the kubeconfig file.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "path": {
+                                            "description": "Path to the kubeconfig file.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "labels": {
+                                    "description": "labels EXPRESSION — expose only objects matching the selector.",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "multicluster": {
+                                    "description": "multicluster ZONES... — MCS-API multicluster zones.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "namespaceLabels": {
+                                    "description": "namespace_labels EXPRESSION — expose only namespaces matching the selector.",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "namespaces": {
+                                    "description": "namespaces NAMESPACE... — expose only these namespaces.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "noendpoints": {
+                                    "description": "noendpoints — disable endpoint record serving.",
+                                    "type": "boolean"
+                                },
+                                "pods": {
+                                    "description": "pods — pod record mode.",
+                                    "type": "string",
+                                    "enum": [
+                                        "disabled",
+                                        "insecure",
+                                        "verified"
+                                    ]
+                                },
+                                "startupTimeout": {
+                                    "description": "startup_timeout — wait for informer cache sync at startup.",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "tls": {
+                                    "description": "tls CERT KEY CACERT — for a remote k8s connection.",
+                                    "type": "object",
+                                    "properties": {
+                                        "ca": {
+                                            "description": "CA cert file path.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "cert": {
+                                            "description": "Client cert file path.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "key": {
+                                            "description": "Client key file path.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "ttl": {
+                                    "description": "ttl SECONDS (0–3600).",
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ],
+                                    "maximum": 3600,
+                                    "minimum": 0
+                                }
+                            }
+                        },
+                        "loadbalance": {
+                            "description": "Load balancing policy. Omit to fall back to round_robin.",
+                            "type": "string",
+                            "enum": [
+                                "round_robin",
+                                "random"
+                            ]
+                        },
+                        "log": {
+                            "description": "CoreDNS log classes for this zone. Omit to fall back to denial+error.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "success",
+                                    "denial",
+                                    "error",
+                                    "all"
+                                ]
+                            }
+                        },
+                        "podCIDR": {
+                            "description": "Pod CIDR for the reverse zone. Defaults to cluster.calico.CIDR when unset.",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        },
+                        "serviceCIDR": {
+                            "description": "Service CIDR for the reverse zone. Defaults to cluster.kubernetes.API.clusterIPRange when unset.",
+                            "type": [
+                                "null",
+                                "string"
+                            ]
+                        }
+                    }
+                },
+                "custom": {
+                    "description": "Raw Corefile snippet appended verbatim at the end of the configuration.",
+                    "type": "string"
+                },
+                "public": {
+                    "description": "The \".\" zone — external/public DNS served by the forward plugin.",
+                    "type": "object",
+                    "properties": {
+                        "autopath": {
+                            "description": "autopath plugin args, e.g. \"@kubernetes\". Empty disables autopath.",
+                            "type": "string"
+                        },
+                        "cache": {
+                            "description": "Cache plugin configuration for this zone (https://coredns.io/plugins/cache/).",
+                            "type": "object",
+                            "properties": {
+                                "denial": {
+                                    "description": "Caching of negative (NXDOMAIN/NODATA) responses.",
+                                    "type": "object",
+                                    "properties": {
+                                        "capacity": {
+                                            "description": "Maximum number of cached negative responses.",
+                                            "type": "integer"
+                                        },
+                                        "minTTL": {
+                                            "description": "Min TTL for negative responses (seconds).",
+                                            "type": [
+                                                "null",
+                                                "integer"
+                                            ]
+                                        },
+                                        "ttl": {
+                                            "description": "Max TTL for negative responses (seconds).",
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "disable": {
+                                    "description": "Selectively disable caching.",
+                                    "type": "object",
+                                    "properties": {
+                                        "denial": {
+                                            "description": "Disable caching of negative responses.",
+                                            "type": [
+                                                "null",
+                                                "boolean"
+                                            ]
+                                        },
+                                        "denialZones": {
+                                            "description": "Limit the denial disable to these zones.",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "success": {
+                                            "description": "Disable caching of positive responses.",
+                                            "type": [
+                                                "null",
+                                                "boolean"
+                                            ]
+                                        },
+                                        "successZones": {
+                                            "description": "Limit the success disable to these zones.",
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "keepttl": {
+                                    "description": "Preserve original TTLs instead of counting them down.",
+                                    "type": "boolean"
+                                },
+                                "prefetch": {
+                                    "description": "Prefetch popular entries before they expire.",
+                                    "type": "object",
+                                    "properties": {
+                                        "amount": {
+                                            "description": "Prefetch when at least this many requests are received (enables prefetch).",
+                                            "type": [
+                                                "null",
+                                                "integer"
+                                            ]
+                                        },
+                                        "duration": {
+                                            "description": "Only prefetch if the item was requested within this duration.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "percentage": {
+                                            "description": "Only prefetch if this percentage of the TTL remains (requires duration).",
+                                            "type": [
+                                                "null",
+                                                "integer"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "serveStale": {
+                                    "description": "Serve stale answers while refreshing in the background.",
+                                    "type": "object",
+                                    "properties": {
+                                        "duration": {
+                                            "description": "How long stale answers may be served.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "enabled": {
+                                            "description": "Enable serving stale answers.",
+                                            "type": "boolean"
+                                        },
+                                        "refreshMode": {
+                                            "description": "Refresh mode.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ],
+                                            "enum": [
+                                                "immediate",
+                                                "verify",
+                                                null
+                                            ]
+                                        },
+                                        "verifyTimeout": {
+                                            "description": "With refreshMode verify — max wait for upstream verify before serving stale.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "servfail": {
+                                    "description": "SERVFAIL caching.",
+                                    "type": "object",
+                                    "properties": {
+                                        "duration": {
+                                            "description": "How long to cache SERVFAIL responses.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "success": {
+                                    "description": "Caching of positive (success) responses.",
+                                    "type": "object",
+                                    "properties": {
+                                        "capacity": {
+                                            "description": "Maximum number of cached positive responses.",
+                                            "type": "integer"
+                                        },
+                                        "minTTL": {
+                                            "description": "Min TTL for positive responses (seconds).",
+                                            "type": [
+                                                "null",
+                                                "integer"
+                                            ]
+                                        },
+                                        "ttl": {
+                                            "description": "Max TTL for positive responses (seconds). Defaults to configmap.cache for backward compatibility.",
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "ttl": {
+                                    "description": "Top-level TTL cap applied before the success/denial checks (seconds).",
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                },
+                                "zones": {
+                                    "description": "Cache ZONES — limit caching to these zones. Empty means the server-block zones.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "forward": {
+                            "description": "Forward plugin configuration (https://coredns.io/plugins/forward/). The FROM is always \".\". Only a representative subset of parameters is wired up today; leave a key unset to keep the CoreDNS default.",
+                            "type": "object",
+                            "properties": {
+                                "dohMethod": {
+                                    "description": "doh_method — HTTP method for DoH requests.",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ],
+                                    "enum": [
+                                        "GET",
+                                        "POST",
+                                        null
+                                    ]
+                                },
+                                "except": {
+                                    "description": "except NAMES — domains to pass through unforwarded.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "expire": {
+                                    "description": "expire — close idle upstream connections after this duration.",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "failfastAllUnhealthyUpstreams": {
+                                    "description": "failfast_all_unhealthy_upstreams — SERVFAIL when all upstreams are down.",
+                                    "type": "boolean"
+                                },
+                                "failover": {
+                                    "description": "failover RCODE... — retry the next upstream on these rcodes (e.g. [SERVFAIL, REFUSED]).",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "forceTCP": {
+                                    "description": "force_tcp — always use TCP to the upstream.",
+                                    "type": "boolean"
+                                },
+                                "healthCheck": {
+                                    "description": "health_check DURATION [no_rec] [domain FQDN].",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "maxConcurrent": {
+                                    "description": "max_concurrent — maximum number of concurrent queries to forward.",
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                },
+                                "maxConnectAttempts": {
+                                    "description": "max_connect_attempts — cap on connect attempts per request (0 = no cap).",
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                },
+                                "maxFails": {
+                                    "description": "max_fails — consecutive failed health checks before marking an upstream down.",
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                },
+                                "maxIdleConns": {
+                                    "description": "max_idle_conns — idle connections cached per upstream (0 = unlimited).",
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
+                                },
+                                "next": {
+                                    "description": "next RCODE... — run the next forward plugin on these rcodes (e.g. [NXDOMAIN]).",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "nextOnNodata": {
+                                    "description": "next_on_nodata — run the next forward plugin on empty NOERROR answers.",
+                                    "type": "boolean"
+                                },
+                                "policy": {
+                                    "description": "policy — upstream selection policy.",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ],
+                                    "enum": [
+                                        "random",
+                                        "round_robin",
+                                        "sequential",
+                                        null
+                                    ]
+                                },
+                                "preferUDP": {
+                                    "description": "prefer_udp — try UDP first even for queries received over TCP.",
+                                    "type": "boolean"
+                                },
+                                "resolver": {
+                                    "description": "resolver IP[:PORT]... — resolvers for hostname-based \"to\" endpoints.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "tls": {
+                                    "description": "tls CERT KEY CA — set cert+key, ca, all three, or enabled for bare tls.",
+                                    "type": "object",
+                                    "properties": {
+                                        "ca": {
+                                            "description": "CA cert file path.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "cert": {
+                                            "description": "Client cert file path.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        },
+                                        "enabled": {
+                                            "description": "Emit bare \"tls\" (system CAs, no client auth).",
+                                            "type": "boolean"
+                                        },
+                                        "key": {
+                                            "description": "Client key file path.",
+                                            "type": [
+                                                "null",
+                                                "string"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "tlsServername": {
+                                    "description": "tls_servername NAME — expected server cert name (e.g. dns.quad9.net).",
+                                    "type": [
+                                        "null",
+                                        "string"
+                                    ]
+                                },
+                                "to": {
+                                    "description": "Upstream DNS servers (the forward TO targets). Empty means use /etc/resolv.conf.",
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "loadbalance": {
+                            "description": "Load balancing policy. Omit to fall back to round_robin.",
+                            "type": "string",
+                            "enum": [
+                                "round_robin",
+                                "random"
+                            ]
+                        },
+                        "log": {
+                            "description": "CoreDNS log classes for this zone. Omit to fall back to denial+error.",
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "success",
+                                    "denial",
+                                    "error",
+                                    "all"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "groupID": {
+            "description": "DEPRECATED: use securityContext.runAsGroup. GID the CoreDNS process runs as.",
+            "type": "integer"
+        },
+        "hpa": {
+            "description": "Horizontal Pod Autoscaler configuration.",
+            "type": "object",
+            "properties": {
+                "behavior": {
+                    "description": "Scaling behavior. The stabilization window restricts replica-count flapping when the scaling metrics keep fluctuating.",
+                    "type": "object",
+                    "properties": {
+                        "scaleDown": {
+                            "description": "Scale-down behavior.",
+                            "type": "object",
+                            "properties": {
+                                "stabilizationWindowSeconds": {
+                                    "description": "Seconds to consider while scaling down to prevent flapping.",
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "description": "Enable the HorizontalPodAutoscaler.",
+                    "type": "boolean"
+                },
+                "maxReplicas": {
+                    "description": "Maximum number of replicas.",
+                    "type": "integer"
+                },
+                "metrics": {
+                    "description": "Additional custom metrics for the HPA (autoscaling/v2 metric objects).",
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "minReplicas": {
+                    "description": "Minimum number of replicas.",
+                    "type": "integer"
+                },
+                "targetCPUUtilizationPercentage": {
+                    "description": "Target average CPU utilization percentage.",
+                    "type": "integer"
+                },
+                "targetMemoryUtilizationPercentage": {
+                    "description": "Target average memory utilization percentage. Set to 0 to disable the memory metric.",
+                    "type": "integer"
                 }
             }
         },
         "image": {
-            "description": "CoreDNS container image coordinates.",
+            "description": "Container image for CoreDNS.",
             "type": "object",
             "properties": {
-                "registry": {
-                    "description": "Container registry hostname.",
+                "name": {
+                    "description": "Image repository.",
                     "type": "string"
                 },
-                "name": {
-                    "description": "Image repository path.",
+                "registry": {
+                    "description": "Image registry.",
                     "type": "string"
                 },
                 "tag": {
-                    "description": "Image tag (version).",
+                    "description": "Image tag.",
                     "type": "string"
                 }
             }
         },
+        "loadbalancePolicy": {
+            "description": "DEPRECATED: use coredns.\u003czone\u003e.loadbalance (per-zone). Load balancing policy.",
+            "type": "string",
+            "enum": [
+                "round_robin",
+                "random"
+            ]
+        },
+        "mastersInstance": {
+            "description": "DEPRECATED: use controlPlane. mastersInstance.enabled stays backward compatible — controlPlane.enabled takes precedence only when explicitly set.",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Whether to deploy the control-plane CoreDNS instance.",
+                    "type": "boolean"
+                },
+                "nodeSelector": {
+                    "description": "Node selector for the control-plane CoreDNS instance.",
+                    "type": "object",
+                    "properties": {
+                        "node-role.kubernetes.io/control-plane": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "name": {
+            "description": "Name used for the CoreDNS workload and its resources.",
+            "type": "string"
+        },
+        "namespace": {
+            "description": "Namespace the CoreDNS resources are deployed into.",
+            "type": "string"
+        },
+        "podDisruptionBudget": {
+            "description": "Pod disruption budget for the CoreDNS workloads.",
+            "type": "object",
+            "properties": {
+                "maxUnavailable": {
+                    "description": "Maximum number of pods that can be unavailable to voluntary disruptions.",
+                    "type": [
+                        "integer",
+                        "string"
+                    ]
+                }
+            }
+        },
         "ports": {
-            "description": "Network ports used by CoreDNS. Shared across the Corefile, Deployments, and NetworkPolicy.",
+            "description": "Ports exposed by CoreDNS.",
             "type": "object",
             "properties": {
                 "dns": {
-                    "description": "DNS service port configuration.",
+                    "description": "DNS port configuration.",
                     "type": "object",
                     "properties": {
                         "name": {
-                            "description": "Port name used in Service and container port definitions.",
+                            "description": "Port name.",
                             "type": "string"
                         },
                         "port": {
-                            "description": "Service port (external-facing, typically 53).",
+                            "description": "Service port exposed for DNS.",
                             "type": "integer"
                         },
                         "targetPort": {
-                            "description": "Container port CoreDNS listens on (typically 1053 to avoid requiring CAP_NET_BIND_SERVICE).",
+                            "description": "Container port CoreDNS listens on.",
                             "type": "integer"
                         }
                     }
@@ -463,342 +1029,113 @@
                     "type": "object",
                     "properties": {
                         "port": {
-                            "description": "Port CoreDNS exposes Prometheus metrics on.",
-                            "type": "integer"
+                            "description": "Port for the Prometheus metrics endpoint. Defaults to 9153 when unset.",
+                            "type": [
+                                "null",
+                                "integer"
+                            ]
                         }
                     }
                 }
             }
         },
         "resources": {
-            "description": "CPU and memory resource requests and limits for CoreDNS containers.",
+            "description": "Resource requests and limits for the CoreDNS containers.",
             "type": "object",
             "properties": {
                 "limits": {
+                    "description": "Resource limits.",
                     "type": "object",
                     "properties": {
                         "memory": {
+                            "description": "Memory limit.",
                             "type": "string"
                         }
                     }
                 },
                 "requests": {
+                    "description": "Resource requests.",
                     "type": "object",
                     "properties": {
                         "cpu": {
+                            "description": "CPU request.",
                             "type": "string"
                         },
                         "memory": {
+                            "description": "Memory request.",
                             "type": "string"
                         }
                     }
                 }
             }
         },
-        "updateStrategy": {
-            "description": "Deployment update strategy.",
+        "securityContext": {
+            "description": "Pod-level security context for the CoreDNS containers.",
             "type": "object",
             "properties": {
-                "type": {
-                    "type": "string"
+                "runAsGroup": {
+                    "description": "GID the CoreDNS process runs as. Defaults to groupID when unset.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
                 },
+                "runAsUser": {
+                    "description": "UID the CoreDNS process runs as. Defaults to userID when unset.",
+                    "type": [
+                        "null",
+                        "integer"
+                    ]
+                }
+            }
+        },
+        "service": {
+            "description": "Configuration for the CoreDNS Service.",
+            "type": "object",
+            "properties": {
+                "clusterIP": {
+                    "description": "Cluster IP of the DNS Service. Defaults to cluster.kubernetes.DNS.IP when unset.",
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                }
+            }
+        },
+        "serviceType": {
+            "description": "Giant Swarm service type label applied to the resources.",
+            "type": "string"
+        },
+        "updateStrategy": {
+            "description": "Update strategy for the CoreDNS workloads.",
+            "type": "object",
+            "properties": {
                 "rollingUpdate": {
+                    "description": "Rolling update parameters.",
                     "type": "object",
                     "properties": {
                         "maxUnavailable": {
-                            "type": ["string", "integer"]
-                        }
-                    }
-                }
-            }
-        },
-        "podDisruptionBudget": {
-            "description": "PodDisruptionBudget spec. Only created when hpa.maxReplicas > 1.",
-            "type": "object",
-            "properties": {
-                "maxUnavailable": {
-                    "type": "string"
-                }
-            }
-        },
-        "hpa": {
-            "description": "HorizontalPodAutoscaler configuration for the workers Deployment.",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "description": "Enable the HorizontalPodAutoscaler.",
-                    "type": "boolean"
-                },
-                "minReplicas": {
-                    "description": "Minimum number of CoreDNS replicas.",
-                    "type": "integer"
-                },
-                "maxReplicas": {
-                    "description": "Maximum number of CoreDNS replicas.",
-                    "type": "integer"
-                },
-                "targetCPUUtilizationPercentage": {
-                    "description": "Target CPU utilization percentage for scaling. Set to 0 to disable CPU-based scaling.",
-                    "type": "integer"
-                },
-                "targetMemoryUtilizationPercentage": {
-                    "description": "Target memory utilization percentage for scaling. Set to 0 to disable memory-based scaling.",
-                    "type": "integer"
-                },
-                "metrics": {
-                    "description": "Additional custom HPA metrics.",
-                    "type": "array"
-                },
-                "behavior": {
-                    "description": "HPA scaling behavior configuration.",
-                    "type": "object",
-                    "properties": {
-                        "scaleDown": {
-                            "type": "object",
-                            "properties": {
-                                "stabilizationWindowSeconds": {
-                                    "description": "Seconds to wait before scaling down after a scale-up event. Increase for large clusters to avoid flapping.",
-                                    "type": "integer"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "controlPlane": {
-            "description": "Configuration for the CoreDNS Deployment targeting control-plane nodes.",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "description": "Deploy a dedicated CoreDNS instance on control-plane nodes. When unset, inherits mastersInstance.enabled for backward compatibility.",
-                    "type": "boolean"
-                },
-                "nodeSelector": {
-                    "description": "Node selector labels used to schedule the control-plane CoreDNS pods.",
-                    "type": "object"
-                }
-            }
-        },
-        "coredns": {
-            "description": "CoreDNS Corefile configuration. Cache, logging, and load balancing are configured per zone.",
-            "type": "object",
-            "properties": {
-                "public": {
-                    "description": "Configuration for the '.' (catch-all) forward zone that handles external DNS lookups.",
-                    "type": "object",
-                    "properties": {
-                        "cache": {
-                            "description": "Per-zone cache configuration for the '.' zone.",
-                            "$ref": "#/definitions/cache"
-                        },
-                        "forward": {
-                            "$ref": "#/definitions/forward"
-                        },
-                        "log": {
-                            "description": "Per-zone log classes for the '.' zone.",
-                            "$ref": "#/definitions/log"
-                        },
-                        "loadbalance": {
-                            "description": "Per-zone load balancing policy for the '.' zone.",
-                            "$ref": "#/definitions/loadbalance"
-                        },
-                        "autopath": {
-                            "description": "Autopath plugin arguments (e.g. '@kubernetes'). Leave empty to disable.",
-                            "type": "string"
+                            "description": "Maximum number of pods that can be unavailable during the update.",
+                            "type": [
+                                "integer",
+                                "string"
+                            ]
                         }
                     }
                 },
-                "cluster": {
-                    "description": "Configuration for the cluster-local DNS zone (kubernetes plugin).",
-                    "type": "object",
-                    "properties": {
-                        "domains": {
-                            "description": "List of local cluster domains served by the kubernetes plugin.",
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "serviceCIDR": {
-                            "description": "Kubernetes service IP range (--service-cluster-ip-range). Used by the kubernetes plugin for PTR record handling.",
-                            "type": "string"
-                        },
-                        "podCIDR": {
-                            "description": "Pod network CIDR (--pod-network-cidr). Used by the kubernetes plugin for PTR record handling.",
-                            "type": "string"
-                        },
-                        "cache": {
-                            "description": "Per-zone cache configuration for the cluster-local zone.",
-                            "$ref": "#/definitions/cache"
-                        },
-                        "kubernetes": {
-                            "$ref": "#/definitions/kubernetes"
-                        },
-                        "log": {
-                            "description": "Per-zone log classes for the cluster-local zone.",
-                            "$ref": "#/definitions/log"
-                        },
-                        "loadbalance": {
-                            "description": "Per-zone load balancing policy for the cluster-local zone.",
-                            "$ref": "#/definitions/loadbalance"
-                        }
-                    }
-                },
-                "additionalZones": {
-                    "description": "Additional local DNS zones, each rendered as its own fully-templated CoreDNS server block.",
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": ["names"],
-                        "properties": {
-                            "names": {
-                                "description": "Zone names served by this server block.",
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "cidrs": {
-                                "description": "Optional reverse (PTR) ranges, appended to the zone line and the kubernetes directive args.",
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "cache": {
-                                "description": "Optional per-zone cache configuration. Omit to use built-in defaults.",
-                                "$ref": "#/definitions/cache"
-                            },
-                            "forward": {
-                                "$ref": "#/definitions/forward"
-                            },
-                            "kubernetes": {
-                                "$ref": "#/definitions/kubernetes"
-                            },
-                            "log": {
-                                "description": "Optional per-zone log classes. Omit to use built-in defaults.",
-                                "$ref": "#/definitions/log"
-                            },
-                            "loadbalance": {
-                                "description": "Optional per-zone load balancing policy. Omit to use built-in defaults.",
-                                "$ref": "#/definitions/loadbalance"
-                            }
-                        }
-                    }
-                },
-                "custom": {
-                    "description": "Raw Corefile content appended verbatim at the end of the generated Corefile. Use for plugins or directives not covered by the structured values.",
-                    "type": "string"
-                }
-            }
-        },
-        "adopter": {
-            "description": "One-shot Job that adopts existing CoreDNS resources during initial chart installation.",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "description": "Run the adopter Job on install.",
-                    "type": "boolean"
-                },
-                "image": {
-                    "description": "Full image reference (registry/name:tag) for the adopter Job container.",
-                    "type": "string"
+                "type": {
+                    "description": "Update strategy type.",
+                    "type": "string",
+                    "enum": [
+                        "RollingUpdate",
+                        "OnDelete"
+                    ]
                 }
             }
         },
         "userID": {
-            "description": "DEPRECATED: use securityContext.runAsUser",
+            "description": "DEPRECATED: use securityContext.runAsUser. UID the CoreDNS process runs as.",
             "type": "integer"
-        },
-        "groupID": {
-            "description": "DEPRECATED: use securityContext.runAsGroup",
-            "type": "integer"
-        },
-        "mastersInstance": {
-            "description": "DEPRECATED: use controlPlane",
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "default": true
-                },
-                "nodeSelector": {
-                    "type": "object"
-                }
-            }
-        },
-        "loadbalancePolicy": {
-            "description": "DEPRECATED: use coredns.<zone>.loadbalance (per-zone)",
-            "type": "string"
-        },
-        "cluster": {
-            "description": "DEPRECATED: use coredns.cluster.* and service.clusterIP",
-            "type": "object",
-            "properties": {
-                "calico": {
-                    "type": "object",
-                    "properties": {
-                        "CIDR": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "kubernetes": {
-                    "type": "object",
-                    "properties": {
-                        "API": {
-                            "type": "object",
-                            "properties": {
-                                "clusterIPRange": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "DNS": {
-                            "type": "object",
-                            "properties": {
-                                "IP": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "clusterDomain": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "configmap": {
-            "description": "DEPRECATED: use coredns.* instead",
-            "type": "object",
-            "properties": {
-                "cache": {
-                    "description": "DEPRECATED: use coredns.public.cache.success.ttl / coredns.cluster.cache.success.ttl",
-                    "type": "integer"
-                },
-                "log": {
-                    "description": "DEPRECATED: use coredns.<zone>.log (per-zone)",
-                    "type": "string"
-                },
-                "custom": {
-                    "description": "DEPRECATED: use coredns.custom",
-                    "type": "string"
-                },
-                "forward": {
-                    "description": "DEPRECATED: use coredns.public.forward.to",
-                    "type": "string"
-                },
-                "forwardOptions": {
-                    "description": "DEPRECATED: use coredns.public.forward",
-                    "type": "string"
-                },
-                "autopath": {
-                    "description": "DEPRECATED: use coredns.public.autopath",
-                    "type": "string"
-                }
-            }
         }
     }
 }

--- a/helm/coredns-app/values.yaml
+++ b/helm/coredns-app/values.yaml
@@ -1,215 +1,420 @@
-# Default values for coredns-chart
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
+# -- Name used for the CoreDNS workload and its resources.
 name: coredns
+# -- Namespace the CoreDNS resources are deployed into.
 namespace: kube-system
+# -- Giant Swarm service type label applied to the resources.
 serviceType: managed
 
-# ── Pod security context ──────────────────────────────────────────────────────
-securityContext: {}
-# runAsUser: 33  # defaults to userID; set securityContext.runAsUser to override
-# runAsGroup: 33 # defaults to groupID; set securityContext.runAsGroup to override
+# -- Pod-level security context for the CoreDNS containers.
+securityContext:
+  # @schema type: [null, integer]
+  # -- UID the CoreDNS process runs as. Defaults to userID when unset.
+  runAsUser:
+  # @schema type: [null, integer]
+  # -- GID the CoreDNS process runs as. Defaults to groupID when unset.
+  runAsGroup:
 
-# ── Service ──────────────────────────────────────────────────────────────────
-service: {}
-# clusterIP: 172.31.0.10  # defaults to cluster.kubernetes.DNS.IP; set service.clusterIP to override
+# -- Configuration for the CoreDNS Service.
+service:
+  # @schema type: [null, string]
+  # -- Cluster IP of the DNS Service. Defaults to cluster.kubernetes.DNS.IP when unset.
+  clusterIP:
 
-# ── Image ────────────────────────────────────────────────────────────────────
+# -- Container image for CoreDNS.
 image:
+  # -- Image registry.
   registry: gsoci.azurecr.io
+  # -- Image repository.
   name: giantswarm/coredns
+  # -- Image tag.
   tag: 1.14.4
 
-# ── Ports ────────────────────────────────────────────────────────────────────
+# -- Ports exposed by CoreDNS.
 ports:
+  # -- DNS port configuration.
   dns:
+    # -- Port name.
     name: dns
+    # -- Container port CoreDNS listens on.
     targetPort: 1053
+    # -- Service port exposed for DNS.
     port: 53
-  metrics: {}
-  # port: 9153  # defaults to ports.prometheus; set ports.metrics.port to override
+  # -- Prometheus metrics port configuration.
+  metrics:
+    # @schema type: [null, integer]
+    # -- Port for the Prometheus metrics endpoint. Defaults to 9153 when unset.
+    port:
 
-# ── Workload ──────────────────────────────────────────────────────────────────
+# -- Resource requests and limits for the CoreDNS containers.
 resources:
+  # -- Resource limits.
   limits:
+    # -- Memory limit.
     memory: 1Gi
+  # -- Resource requests.
   requests:
+    # -- CPU request.
     cpu: 250m
+    # -- Memory request.
     memory: 512Mi
 
+# -- Update strategy for the CoreDNS workloads.
 updateStrategy:
+  # @schema enum: [RollingUpdate, OnDelete]
+  # -- Update strategy type.
   type: RollingUpdate
+  # -- Rolling update parameters.
   rollingUpdate:
+    # @schema type: [integer, string]
+    # -- Maximum number of pods that can be unavailable during the update.
     maxUnavailable: 1
 
+# -- Pod disruption budget for the CoreDNS workloads.
 podDisruptionBudget:
+  # @schema type: [integer, string]
+  # -- Maximum number of pods that can be unavailable to voluntary disruptions.
   maxUnavailable: 25%
 
-# ── Scaling ───────────────────────────────────────────────────────────────────
+# -- Horizontal Pod Autoscaler configuration.
 hpa:
+  # -- Enable the HorizontalPodAutoscaler.
   enabled: true
+  # -- Minimum number of replicas.
   minReplicas: 2
+  # -- Maximum number of replicas.
   maxReplicas: 50
+  # -- Target average CPU utilization percentage.
   targetCPUUtilizationPercentage: 80
+  # -- Target average memory utilization percentage. Set to 0 to disable the memory metric.
   targetMemoryUtilizationPercentage: 0
+  # @schema item: object
+  # -- Additional custom metrics for the HPA (autoscaling/v2 metric objects).
   metrics: []
-  # The stabilization window is used to restrict the flapping of replica count
-  # when the metrics used for scaling keep fluctuating.
+  # -- Scaling behavior. The stabilization window restricts replica-count flapping when the scaling metrics keep fluctuating.
   behavior:
+    # -- Scale-down behavior.
     scaleDown:
+      # -- Seconds to consider while scaling down to prevent flapping.
       stabilizationWindowSeconds: 1800
 
-# ── Control-plane instance ────────────────────────────────────────────────────
+# -- Control-plane CoreDNS instance configuration.
 controlPlane:
-  # enabled: true  # defaults to mastersInstance.enabled for backward compat; set explicitly to override
+  # @schema type: [null, boolean]
+  # -- Whether to deploy the control-plane CoreDNS instance. Defaults to mastersInstance.enabled for backward compatibility.
+  enabled:
+  # -- Node selector for the control-plane CoreDNS instance.
   nodeSelector:
     "node-role.kubernetes.io/control-plane": '""'
 
-# ── CoreDNS Corefile configuration ───────────────────────────────────────────
-# Cache, log, and loadbalance are configured per zone (coredns.public.*, coredns.cluster.*,
-# and each coredns.additionalZones[].*), so different zones can behave differently. A zone
-# that omits `cache` falls back to the built-in defaults (success 9984 30 / denial 9984 5);
-# a zone that omits `log`/`loadbalance` falls back to denial+error / round_robin.
+# -- CoreDNS Corefile configuration. Cache, log and loadbalance are configured per zone, so different zones can behave differently. A zone that omits cache falls back to the built-in defaults (success 9984 30 / denial 9984 5); a zone that omits log/loadbalance falls back to denial+error / round_robin.
 coredns:
-  # "." zone — external/public DNS (forward zone)
-  # Structured forward directive, mirroring the CoreDNS forward block
-  # (https://coredns.io/plugins/forward/). The FROM is always "."; `to` holds the
-  # upstream targets and the remaining keys are forward-plugin parameters. Only a
-  # representative subset is wired up today; the block is designed to be extended one
-  # key at a time. Leave a key unset to keep the CoreDNS default.
+  # -- The "." zone — external/public DNS served by the forward plugin.
   public:
+    # -- Cache plugin configuration for this zone (https://coredns.io/plugins/cache/).
     cache:
-      # ttl: 30              # top-level TTL cap applied before success/denial checks
-      # zones: []            # cache ZONES... — limit caching to these zones (default: server-block zones)
+      # @schema type: [null, integer]
+      # -- Top-level TTL cap applied before the success/denial checks (seconds).
+      ttl:
+      # @schema item: string
+      # -- Cache ZONES — limit caching to these zones. Empty means the server-block zones.
+      zones: []
+      # -- Caching of positive (success) responses.
       success:
-        capacity: 9984       # max number of cached positive responses
-        ttl: 30              # max TTL; defaults to configmap.cache for backward compat
-        # minTTL: 0          # min TTL for positive responses
+        # -- Maximum number of cached positive responses.
+        capacity: 9984
+        # -- Max TTL for positive responses (seconds). Defaults to configmap.cache for backward compatibility.
+        ttl: 30
+        # @schema type: [null, integer]
+        # -- Min TTL for positive responses (seconds).
+        minTTL:
+      # -- Caching of negative (NXDOMAIN/NODATA) responses.
       denial:
-        capacity: 9984       # max number of cached NXDOMAIN/NODATA responses
-        ttl: 5               # max TTL
-        # minTTL: 0          # min TTL for denial responses
-      # prefetch:
-      #   amount: 10         # enable prefetch when this many requests received (required)
-      #   duration: 1m       # only prefetch if item was requested within this duration
-      #   percentage: 20     # only prefetch if this % of TTL remains (requires duration)
+        # -- Maximum number of cached negative responses.
+        capacity: 9984
+        # -- Max TTL for negative responses (seconds).
+        ttl: 5
+        # @schema type: [null, integer]
+        # -- Min TTL for negative responses (seconds).
+        minTTL:
+      # -- Prefetch popular entries before they expire.
+      prefetch:
+        # @schema type: [null, integer]
+        # -- Prefetch when at least this many requests are received (enables prefetch).
+        amount:
+        # @schema type: [null, string]
+        # -- Only prefetch if the item was requested within this duration.
+        duration:
+        # @schema type: [null, integer]
+        # -- Only prefetch if this percentage of the TTL remains (requires duration).
+        percentage:
+      # -- Serve stale answers while refreshing in the background.
       serveStale:
-        enabled: false       # serve stale answers while refreshing in background
-        # duration: 1h       # how long stale answers may be served
-        # refreshMode: ""    # immediate | verify
-        # verifyTimeout: 100ms # only with refreshMode verify — max wait for upstream verify before serving stale
-      # servfail:
-      #   duration: 5s       # how long to cache SERVFAIL responses
-      # disable:
-      #   success: false     # disable caching of positive responses
-      #   successZones: []   # disable success ZONES... — limit the disable to these zones
-      #   denial: false      # disable caching of NXDOMAIN/NODATA responses
-      #   denialZones: []    # disable denial ZONES... — limit the disable to these zones
-      # keepttl: false       # preserve original TTLs instead of counting down
+        # -- Enable serving stale answers.
+        enabled: false
+        # @schema type: [null, string]
+        # -- How long stale answers may be served.
+        duration:
+        # @schema type: [null, string]; enum: [immediate, verify, null]
+        # -- Refresh mode.
+        refreshMode:
+        # @schema type: [null, string]
+        # -- With refreshMode verify — max wait for upstream verify before serving stale.
+        verifyTimeout:
+      # -- SERVFAIL caching.
+      servfail:
+        # @schema type: [null, string]
+        # -- How long to cache SERVFAIL responses.
+        duration:
+      # -- Selectively disable caching.
+      disable:
+        # @schema type: [null, boolean]
+        # -- Disable caching of positive responses.
+        success:
+        # @schema item: string
+        # -- Limit the success disable to these zones.
+        successZones: []
+        # @schema type: [null, boolean]
+        # -- Disable caching of negative responses.
+        denial:
+        # @schema item: string
+        # -- Limit the denial disable to these zones.
+        denialZones: []
+      # -- Preserve original TTLs instead of counting them down.
+      keepttl: false
+    # -- Forward plugin configuration (https://coredns.io/plugins/forward/). The FROM is always ".". Only a representative subset of parameters is wired up today; leave a key unset to keep the CoreDNS default.
     forward:
-      to: []                # upstream DNS servers (the forward "TO..." targets); empty means use /etc/resolv.conf
-      # except: []            # except NAMES... — domains to pass through unforwarded
-      # forceTCP: false       # force_tcp — always use TCP to the upstream
-      # preferUDP: false      # prefer_udp — try UDP first even for queries received over TCP
-      # expire: 10s           # expire — close idle upstream connections after this duration
-      # maxIdleConns: 0       # max_idle_conns — idle connections cached per upstream (0 = unlimited)
-      # maxFails: 2           # max_fails — consecutive failed health checks before marking an upstream down
-      # maxConnectAttempts: 0 # max_connect_attempts — cap on connect attempts per request (0 = no cap)
-      # dohMethod: POST       # doh_method — GET | POST for DoH requests
-      # tls:                  # tls CERT KEY CA — set cert+key, ca, all three, or enabled for bare tls
-      #   enabled: false      #   emit bare "tls" (system CAs, no client auth)
-      #   cert: ""            #   client cert file path
-      #   key: ""             #   client key file path
-      #   ca: ""              #   CA cert file path
-      # tlsServername: ""     # tls_servername NAME — expected server cert name (e.g. dns.quad9.net)
-      # policy: random        # random | round_robin | sequential
-      # healthCheck: 0.2s     # health_check DURATION [no_rec] [domain FQDN]
-      # maxConcurrent: 1000   # max_concurrent — maximum number of concurrent queries to forward
-      # next: []              # next RCODE... — run next forward plugin on these rcodes (e.g. [NXDOMAIN])
-      # nextOnNodata: false   # next_on_nodata — run next forward plugin on empty NOERROR answers
-      # failfastAllUnhealthyUpstreams: false # failfast_all_unhealthy_upstreams — SERVFAIL when all down
-      # failover: []          # failover RCODE... — retry next upstream on these rcodes (e.g. [SERVFAIL, REFUSED])
-      # resolver: []          # resolver IP[:PORT]... — resolvers for hostname-based "to" endpoints
-    log:                  # CoreDNS log classes for this zone; omit to fall back to denial+error
+      # @schema item: string
+      # -- Upstream DNS servers (the forward TO targets). Empty means use /etc/resolv.conf.
+      to: []
+      # @schema item: string
+      # -- except NAMES — domains to pass through unforwarded.
+      except: []
+      # -- force_tcp — always use TCP to the upstream.
+      forceTCP: false
+      # -- prefer_udp — try UDP first even for queries received over TCP.
+      preferUDP: false
+      # @schema type: [null, string]
+      # -- expire — close idle upstream connections after this duration.
+      expire:
+      # @schema type: [null, integer]
+      # -- max_idle_conns — idle connections cached per upstream (0 = unlimited).
+      maxIdleConns:
+      # @schema type: [null, integer]
+      # -- max_fails — consecutive failed health checks before marking an upstream down.
+      maxFails:
+      # @schema type: [null, integer]
+      # -- max_connect_attempts — cap on connect attempts per request (0 = no cap).
+      maxConnectAttempts:
+      # @schema type: [null, string]; enum: [GET, POST, null]
+      # -- doh_method — HTTP method for DoH requests.
+      dohMethod:
+      # -- tls CERT KEY CA — set cert+key, ca, all three, or enabled for bare tls.
+      tls:
+        # -- Emit bare "tls" (system CAs, no client auth).
+        enabled: false
+        # @schema type: [null, string]
+        # -- Client cert file path.
+        cert:
+        # @schema type: [null, string]
+        # -- Client key file path.
+        key:
+        # @schema type: [null, string]
+        # -- CA cert file path.
+        ca:
+      # @schema type: [null, string]
+      # -- tls_servername NAME — expected server cert name (e.g. dns.quad9.net).
+      tlsServername:
+      # @schema type: [null, string]; enum: [random, round_robin, sequential, null]
+      # -- policy — upstream selection policy.
+      policy:
+      # @schema type: [null, string]
+      # -- health_check DURATION [no_rec] [domain FQDN].
+      healthCheck:
+      # @schema type: [null, integer]
+      # -- max_concurrent — maximum number of concurrent queries to forward.
+      maxConcurrent:
+      # @schema item: string
+      # -- next RCODE... — run the next forward plugin on these rcodes (e.g. [NXDOMAIN]).
+      next: []
+      # -- next_on_nodata — run the next forward plugin on empty NOERROR answers.
+      nextOnNodata: false
+      # -- failfast_all_unhealthy_upstreams — SERVFAIL when all upstreams are down.
+      failfastAllUnhealthyUpstreams: false
+      # @schema item: string
+      # -- failover RCODE... — retry the next upstream on these rcodes (e.g. [SERVFAIL, REFUSED]).
+      failover: []
+      # @schema item: string
+      # -- resolver IP[:PORT]... — resolvers for hostname-based "to" endpoints.
+      resolver: []
+    # @schema itemEnum: [success, denial, error, all]
+    # -- CoreDNS log classes for this zone. Omit to fall back to denial+error.
+    log:
       - denial
       - error
-    loadbalance: round_robin  # round_robin | random; omit to fall back to round_robin
-    autopath: ""        # autopath plugin args, e.g. "@kubernetes" (optional)
+    # @schema enum: [round_robin, random]
+    # -- Load balancing policy. Omit to fall back to round_robin.
+    loadbalance: round_robin
+    # -- autopath plugin args, e.g. "@kubernetes". Empty disables autopath.
+    autopath: ""
 
-  # cluster.local zone — in-cluster DNS (kubernetes plugin)
+  # -- The cluster.local zone — in-cluster DNS served by the kubernetes plugin.
   cluster:
-    # domains: [cluster.local]   # defaults to cluster.kubernetes.clusterDomain; set coredns.cluster.domains to override
-    # serviceCIDR: 172.31.0.0/16 # defaults to cluster.kubernetes.API.clusterIPRange; set coredns.cluster.serviceCIDR to override
-    # podCIDR: 192.168.0.0/16    # defaults to cluster.calico.CIDR; set coredns.cluster.podCIDR to override
+    # @schema type: [null, array]
+    # -- Zone names served by this block. Defaults to cluster.kubernetes.clusterDomain when unset.
+    domains:
+    # @schema type: [null, string]
+    # -- Service CIDR for the reverse zone. Defaults to cluster.kubernetes.API.clusterIPRange when unset.
+    serviceCIDR:
+    # @schema type: [null, string]
+    # -- Pod CIDR for the reverse zone. Defaults to cluster.calico.CIDR when unset.
+    podCIDR:
+    # -- Cache plugin configuration for this zone (https://coredns.io/plugins/cache/).
     cache:
-      # ttl: 30              # top-level TTL cap applied before success/denial checks
-      # zones: []            # cache ZONES... — limit caching to these zones (default: server-block zones)
+      # @schema type: [null, integer]
+      # -- Top-level TTL cap applied before the success/denial checks (seconds).
+      ttl:
+      # @schema item: string
+      # -- Cache ZONES — limit caching to these zones. Empty means the server-block zones.
+      zones: []
+      # -- Caching of positive (success) responses.
       success:
-        capacity: 9984       # max number of cached positive responses
-        ttl: 30              # max TTL; defaults to configmap.cache for backward compat
-        # minTTL: 0          # min TTL for positive responses
+        # -- Maximum number of cached positive responses.
+        capacity: 9984
+        # -- Max TTL for positive responses (seconds). Defaults to configmap.cache for backward compatibility.
+        ttl: 30
+        # @schema type: [null, integer]
+        # -- Min TTL for positive responses (seconds).
+        minTTL:
+      # -- Caching of negative (NXDOMAIN/NODATA) responses.
       denial:
-        capacity: 9984       # max number of cached NXDOMAIN/NODATA responses
-        ttl: 5               # max TTL
-        # minTTL: 0          # min TTL for denial responses
-      # prefetch:
-      #   amount: 10
-      #   duration: 1m
-      #   percentage: 20
+        # -- Maximum number of cached negative responses.
+        capacity: 9984
+        # -- Max TTL for negative responses (seconds).
+        ttl: 5
+        # @schema type: [null, integer]
+        # -- Min TTL for negative responses (seconds).
+        minTTL:
+      # -- Prefetch popular entries before they expire.
+      prefetch:
+        # @schema type: [null, integer]
+        # -- Prefetch when at least this many requests are received (enables prefetch).
+        amount:
+        # @schema type: [null, string]
+        # -- Only prefetch if the item was requested within this duration.
+        duration:
+        # @schema type: [null, integer]
+        # -- Only prefetch if this percentage of the TTL remains (requires duration).
+        percentage:
+      # -- Serve stale answers while refreshing in the background.
       serveStale:
-        enabled: false       # serve stale answers while refreshing in background
-        # duration: 1h
-        # refreshMode: ""    # immediate | verify
-        # verifyTimeout: 100ms # only with refreshMode verify — max wait for upstream verify before serving stale
-      # servfail:
-      #   duration: 5s
-      # disable:
-      #   success: false
-      #   successZones: []
-      #   denial: false
-      #   denialZones: []
-      # keepttl: false
-    # Structured kubernetes-plugin parameters, mirroring the CoreDNS kubernetes block
-    # (https://coredns.io/plugins/kubernetes/). Leave a key unset to keep the CoreDNS default.
+        # -- Enable serving stale answers.
+        enabled: false
+        # @schema type: [null, string]
+        # -- How long stale answers may be served.
+        duration:
+        # @schema type: [null, string]; enum: [immediate, verify, null]
+        # -- Refresh mode.
+        refreshMode:
+        # @schema type: [null, string]
+        # -- With refreshMode verify — max wait for upstream verify before serving stale.
+        verifyTimeout:
+      # -- SERVFAIL caching.
+      servfail:
+        # @schema type: [null, string]
+        # -- How long to cache SERVFAIL responses.
+        duration:
+      # -- Selectively disable caching.
+      disable:
+        # @schema type: [null, boolean]
+        # -- Disable caching of positive responses.
+        success:
+        # @schema item: string
+        # -- Limit the success disable to these zones.
+        successZones: []
+        # @schema type: [null, boolean]
+        # -- Disable caching of negative responses.
+        denial:
+        # @schema item: string
+        # -- Limit the denial disable to these zones.
+        denialZones: []
+      # -- Preserve original TTLs instead of counting them down.
+      keepttl: false
+    # -- Kubernetes plugin configuration (https://coredns.io/plugins/kubernetes/). Leave a key unset to keep the CoreDNS default.
     kubernetes:
-      pods: verified              # pods — disabled | insecure | verified
-      # endpoint: ""              # endpoint URL — remote k8s API endpoint (omit for in-cluster)
-      # tls:                      # tls CERT KEY CACERT — for a remote k8s connection
-      #   cert: ""
-      #   key: ""
-      #   ca: ""
-      # kubeconfig:               # kubeconfig KUBECONFIG [CONTEXT] — authenticate via kubeconfig file
-      #   path: ""
-      #   context: ""
-      # apiserverQPS: 0           # apiserver_qps — max queries-per-second to the API server
-      # apiserverBurst: 0         # apiserver_burst — max burst size for API server requests
-      # apiserverMaxInflight: 0   # apiserver_max_inflight — max concurrent in-flight API server requests
-      # ttl: 5                    # ttl SECONDS (0–3600)
-      # endpointPodNames: false   # endpoint_pod_names — use pod name instead of dashed IP
-      # noendpoints: false        # noendpoints — disable endpoint record serving
-      # namespaces: []            # namespaces NAMESPACE... — expose only these namespaces
-      # namespaceLabels: ""       # namespace_labels EXPRESSION — expose only namespaces matching the selector
-      # labels: ""                # labels EXPRESSION — expose only objects matching the selector
-      # ignoreEmptyService: false # ignore empty_service — NXDOMAIN for services without ready endpoints
-      # fallthrough: false        # fallthrough — pass unresolved queries to the next plugin (all zones)
-      # fallthroughZones: []      # fallthrough ZONES... — limit fallthrough to these zones
-      # multicluster: []          # multicluster ZONES... — MCS-API multicluster zones
-      # startupTimeout: 5s        # startup_timeout — wait for informer cache sync at startup
-    log:                  # CoreDNS log classes for this zone; omit to fall back to denial+error
+      # @schema enum: [disabled, insecure, verified]
+      # -- pods — pod record mode.
+      pods: verified
+      # @schema type: [null, string]
+      # -- endpoint URL — remote k8s API endpoint (omit for in-cluster).
+      endpoint:
+      # -- tls CERT KEY CACERT — for a remote k8s connection.
+      tls:
+        # @schema type: [null, string]
+        # -- Client cert file path.
+        cert:
+        # @schema type: [null, string]
+        # -- Client key file path.
+        key:
+        # @schema type: [null, string]
+        # -- CA cert file path.
+        ca:
+      # -- kubeconfig KUBECONFIG [CONTEXT] — authenticate via a kubeconfig file.
+      kubeconfig:
+        # @schema type: [null, string]
+        # -- Path to the kubeconfig file.
+        path:
+        # @schema type: [null, string]
+        # -- Context within the kubeconfig file.
+        context:
+      # @schema type: [null, integer]
+      # -- apiserver_qps — max queries-per-second to the API server.
+      apiserverQPS:
+      # @schema type: [null, integer]
+      # -- apiserver_burst — max burst size for API server requests.
+      apiserverBurst:
+      # @schema type: [null, integer]
+      # -- apiserver_max_inflight — max concurrent in-flight API server requests.
+      apiserverMaxInflight:
+      # @schema type: [null, integer]; minimum: 0; maximum: 3600
+      # -- ttl SECONDS (0–3600).
+      ttl:
+      # -- endpoint_pod_names — use the pod name instead of the dashed IP.
+      endpointPodNames: false
+      # -- noendpoints — disable endpoint record serving.
+      noendpoints: false
+      # @schema item: string
+      # -- namespaces NAMESPACE... — expose only these namespaces.
+      namespaces: []
+      # @schema type: [null, string]
+      # -- namespace_labels EXPRESSION — expose only namespaces matching the selector.
+      namespaceLabels:
+      # @schema type: [null, string]
+      # -- labels EXPRESSION — expose only objects matching the selector.
+      labels:
+      # -- ignore empty_service — NXDOMAIN for services without ready endpoints.
+      ignoreEmptyService: false
+      # -- fallthrough — pass unresolved queries to the next plugin (all zones).
+      fallthrough: false
+      # @schema item: string
+      # -- fallthrough ZONES... — limit fallthrough to these zones.
+      fallthroughZones: []
+      # @schema item: string
+      # -- multicluster ZONES... — MCS-API multicluster zones.
+      multicluster: []
+      # @schema type: [null, string]
+      # -- startup_timeout — wait for informer cache sync at startup.
+      startupTimeout:
+    # @schema itemEnum: [success, denial, error, all]
+    # -- CoreDNS log classes for this zone. Omit to fall back to denial+error.
+    log:
       - denial
       - error
-    loadbalance: round_robin  # round_robin | random; omit to fall back to round_robin
+    # @schema enum: [round_robin, random]
+    # -- Load balancing policy. Omit to fall back to round_robin.
+    loadbalance: round_robin
 
-  # Additional fully-templated local zones. Each entry is its own CoreDNS server block:
-  #   names       — zone names served by the block (required)
-  #   cidrs       — optional reverse (PTR) ranges, appended to the zone line + kubernetes args
-  #   cache       — optional per-zone cache (same shape as public/cluster; omit for defaults)
-  #   forward     — optional forward block (same shape as coredns.public.forward)
-  #   kubernetes  — optional kubernetes block (same shape as coredns.cluster.kubernetes)
-  #   log         — optional log classes (omit to fall back to denial+error)
-  #   loadbalance — optional policy (omit to fall back to round_robin)
-  # A zone renders whichever of forward/kubernetes it declares (or both, or neither).
+  # @schema item: object
+  # -- Additional fully-templated local zones. Each entry is its own CoreDNS server block and renders whichever of forward/kubernetes it declares (or both, or neither). Per-entry keys: names (required), cidrs, cache, forward, kubernetes, log, loadbalance — same shapes as coredns.public/coredns.cluster.
   additionalZones: []
   # additionalZones:
   #   - names: [linkerd.local]
@@ -225,61 +430,69 @@ coredns:
   #       to: [10.0.0.53]
   #       # policy: random
 
-  custom: ""  # raw Corefile snippet appended verbatim at end
+  # -- Raw Corefile snippet appended verbatim at the end of the configuration.
+  custom: ""
 
-# ── Adopter job ───────────────────────────────────────────────────────────────
+# -- Adopter job that takes ownership of pre-existing CoreDNS resources.
 adopter:
+  # -- Enable the adopter job.
   enabled: false
+  # -- Image used by the adopter job.
   image: gsoci.azurecr.io/giantswarm/docker-kubectl:1.36.1
 
-# ── DEPRECATED ───────────────────────────────────────────────────────────────
-# The following values are superseded by the structure above.
-# They remain for backward compatibility and will be removed in a future major release.
-# NOTE: if you have custom overrides for these values, migrate them to the new paths.
+# The following values are superseded by the structure above. They remain for
+# backward compatibility and will be removed in a future major release. If you
+# have custom overrides for these values, migrate them to the new paths.
 
-# DEPRECATED: use securityContext.runAsUser / securityContext.runAsGroup
+# -- DEPRECATED: use securityContext.runAsUser. UID the CoreDNS process runs as.
 userID: 33
+# -- DEPRECATED: use securityContext.runAsGroup. GID the CoreDNS process runs as.
 groupID: 33
 
-# DEPRECATED: use controlPlane
-# mastersInstance.enabled is backward compatible — controlPlane.enabled takes precedence only when explicitly set
+# -- DEPRECATED: use controlPlane. mastersInstance.enabled stays backward compatible — controlPlane.enabled takes precedence only when explicitly set.
 mastersInstance:
+  # -- Whether to deploy the control-plane CoreDNS instance.
   enabled: true
+  # -- Node selector for the control-plane CoreDNS instance.
   nodeSelector:
     "node-role.kubernetes.io/control-plane": '""'
 
-# DEPRECATED: use coredns.<zone>.loadbalance (per-zone)
+# @schema enum: [round_robin, random]
+# -- DEPRECATED: use coredns.<zone>.loadbalance (per-zone). Load balancing policy.
 loadbalancePolicy: round_robin
 
-# DEPRECATED: use coredns.additionalZones
-# additionalLocalZones: []
-
-# DEPRECATED: use coredns.cluster.* for Corefile config and service.clusterIP for the DNS service IP
+# -- DEPRECATED: use coredns.cluster.* for Corefile config and service.clusterIP for the DNS service IP.
 cluster:
+  # -- Calico configuration.
   calico:
+    # -- Pod CIDR.
     CIDR: 192.168.0.0/16
+  # -- Kubernetes cluster configuration.
   kubernetes:
+    # -- API server configuration.
     API:
+      # -- Service IP range.
       clusterIPRange: 172.31.0.0/16
+    # -- Cluster DNS configuration.
     DNS:
+      # -- Cluster DNS service IP.
       IP: 172.31.0.10
+    # -- Cluster DNS domain.
     clusterDomain: cluster.local
 
-# DEPRECATED: use coredns.* instead
-# coredns.public.cache.success.ttl / coredns.cluster.cache.success.ttl replace configmap.cache
-# coredns.<zone>.log replaces configmap.log (per-zone)
-# coredns.public.forward.to replaces configmap.forward
-# coredns.public.forward.* replaces configmap.forwardOptions
-# coredns.public.autopath replaces configmap.autopath
-# coredns.custom replaces configmap.custom
+# -- DEPRECATED: use coredns.* instead. coredns.public.cache.success.ttl / coredns.cluster.cache.success.ttl replace configmap.cache; coredns.<zone>.log replaces configmap.log; coredns.public.forward.to replaces configmap.forward; coredns.public.forward.* replaces configmap.forwardOptions; coredns.public.autopath replaces configmap.autopath; coredns.custom replaces configmap.custom.
 configmap:
+  # -- DEPRECATED: use coredns.<zone>.cache.success.ttl. Cache TTL seed (seconds).
   cache: 30
+  # -- DEPRECATED: use coredns.custom. Raw Corefile snippet.
   custom: ""
+  # -- DEPRECATED: use coredns.<zone>.log. Newline-separated log classes.
   log: |
     denial
     error
-
-  # Uncomment and define `forward` to enable and configure forwarding rules for CoreDNS forward plugin (for syntax see https://coredns.io/plugins/forward/)
-  # forward: . 192.168.1.1 /etc/resolv.conf
-  # forwardOptions: |
-  #   policy random
+  # @schema type: [null, string]
+  # -- DEPRECATED: use coredns.public.forward.to. Forward directive (see https://coredns.io/plugins/forward/), e.g. ". 192.168.1.1 /etc/resolv.conf".
+  forward:
+  # @schema type: [null, string]
+  # -- DEPRECATED: use coredns.public.forward. Newline-separated forward plugin options.
+  forwardOptions:


### PR DESCRIPTION
## What

Standardize `helm/coredns-app/values.yaml` comments so the `helm schema` plugin (losisin/helm-values-schema-json, `--use-helm-docs`) can generate `values.schema.json` from them, and regenerate the schema.

## Changes

- Remove section header dividers (`# ── … ──`, top banner, deprecated divider).
- Adopt cilium-app comment style: single-line `# @schema …` annotations paired with `# --` helm-docs descriptions.
- Surface previously-commented optional fields as null-valued keys so they're captured by the generator (real defaults kept as actual values).
- Regenerate `values.schema.json` (draft 2020-12).

Generate with:
```
helm schema --use-helm-docs -f values.yaml -o values.schema.json
```

## Verification

- Rendered manifests are **byte-identical** to before (templates treat null as unset via `coalesce`/`with`/`kindIs "invalid"`).
- All `ci/*.yaml` test value files render and validate (`yajsv`) against the new schema.

## Note

The cilium style inlines definitions, so the schema no longer uses `$defs`/`$ref` reuse (cache/forward/kubernetes shapes are duplicated inline) and moved from draft-04 to draft-2020-12.