### PR TITLE
chore(deps): update dependency architect to v9.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@9.5.5
+  architect: giantswarm/architect@9.6.0
 
 workflows:
   build:


### PR DESCRIPTION
Bumps the `architect` orb `9.5.5 → 9.6.0`, which carries the `app-build-suite:2.2.0-circleci` executor (abs v2.2.0).

Effect on coredns-app: its next chart release will build with the new abs, injecting Artifact Hub metadata (`artifacthub.io/license` + a Support link) into the packaged chart — surfacing on https://artifacthub.io/packages/helm/giantswarm-coredns-app/coredns-app. Also newly runs the default-on `HelmTemplateValidator` (fails on duplicate keys / invalid rendered YAML) — this PR's CI is the first check that coredns renders cleanly under it.

Manual bump ahead of Renovate (its datasource cache still shows 9.5.5). Towards [giantswarm/roadmap#3940](https://github.com/giantswarm/roadmap/issues/3940).